### PR TITLE
update to correspond to rstanarm 2.17.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: rstantools
 Type: Package
 Title: Tools for Developing R Packages Interfacing with 'Stan'
-Version: 1.3.0
-Date: 2017-08-01
+Version: 1.4.0
+Date: 2017-12-21
 Authors@R: c(person("Jonah", "Gabry", email = "jsg2201@columbia.edu",
                     role = c("aut", "cre")),
              person("Ben", "Goodrich", email = "benjamin.goodrich@columbia.edu",
@@ -24,8 +24,8 @@ Imports:
     utils
 Suggests:
     bayesplot (>= 1.2.0),
-    rstan (>= 2.16.0),
-    rstanarm (>= 2.15.3),
+    rstan (>= 2.17.2),
+    rstanarm (>= 2.17.2),
     shinystan (>= 2.3.0),
     loo (>= 1.1.0),
     testthat,

--- a/tests/testthat/test-rstan_package_skeleton.R
+++ b/tests/testthat/test-rstan_package_skeleton.R
@@ -17,8 +17,7 @@ if (requireNamespace("rstan", quietly = TRUE)) { # FIXME when travis can install
   test_that("package directory has required structure", {
     expect_equal(
       sort(list.files(pkg_path)),
-      sort(c("cleanup", "cleanup.win", "DESCRIPTION", "exec", "inst", "man",
-             "NAMESPACE", "R", "Read-and-delete-me", "src", "tools"))
+      sort(c("DESCRIPTION", "inst", "man", "NAMESPACE", "R", "Read-and-delete-me", "src", "tools"))
     )
   })
   test_that(".travis.yml file included", {
@@ -32,7 +31,7 @@ if (requireNamespace("rstan", quietly = TRUE)) { # FIXME when travis can install
     expect_true(".Rbuildignore" %in% pkg_files)
   })
   test_that(".stan file included", {
-    expect_true("exec/test.stan" %in% pkg_files)
+    expect_true("src/stan_files/test.stan" %in% pkg_files)
   })
   test_that("R/stanmodels.R file included", {
     expect_true("R/stanmodels.R" %in% pkg_files)

--- a/vignettes/developer-guidelines.Rmd
+++ b/vignettes/developer-guidelines.Rmd
@@ -44,7 +44,7 @@ choose not to, and
 2. refraining from promoting packages that ignore them. 
 
 That said, we are open to some limited exceptions (e.g., the __brms__ package is
-a sanctioned exception to one of guidelines about Stan code). If you think your 
+a sensible exception to one of guidelines about Stan code). If you think your 
 package should be an exception definitely let us know.
 
 
@@ -74,7 +74,7 @@ if (!require("devtools")) {
   install.packages("devtools")
   library("devtools")
 }
-install_github("stan-dev/rstanarm", args = "--preclean", build_vignettes = FALSE)
+install_github("stan-dev/rstanarm")
 ```
 
 * Unit testing is essential. There are several R packages that make it 
@@ -89,25 +89,30 @@ tests, but it's a good first step.
 ### Stan code
 
 * All Stan code for estimating models should be included in pre-written static
-.stan files that are compiled when the package is built (see the exec directory
-in the __rstanarm__ repo for examples). You can also use the inst directory to
+.stan files that are compiled when the package is built (see the src/stan_files directory
+in the __rstanarm__ repo for examples). You can also use its chunks subdirectory to
 include code chunks to be used in multiple .stan files (again see the __rstanarm__
 repo for examples). If you set up your package using `rstan_package_skeleton`
 this structure will be created for you. This means that your package should NOT
 write a Stan program when the user calls a model fitting function in your
 package, but rather use only Stan programs you have written by hand in advance
 (if you are working on a model for which you don't think this is possible please
-let us know). There are several reasons for this. One reason to use pre-compiled
-Stan programs is that models will run immediately when called, avoiding
-compilation time. Second, if you want us to give advice on your Stan code (which
-we are happy to do) it will be easier for us if you write your programs
-following this recommendation. And most importantly, although pre-written static
-Stan programs can still contain bugs, it is much easier to test programs that do
-not change depending on actions taken by the user. To provide flexibility to
-users, your Stan programs can include branching logic (conditional statements)
-so that even with a small number of .stan files you can still allow for many 
-different specifications to made by the user (see the .stan files in
-[__rstanarm__](https://github.com/stan-dev/rstanarm/tree/master/exec) for 
+let us know). There are several reasons for this. 
+
+* Pre-compiled Stan programs can be run by users of Windows or Mac OSX without
+  having to install a C++ compiler, which dramatically expands the universe of
+  potential users for your package.
+* Pre-compiled Stan program will run immediately when called, avoiding compilation time. 
+* CRAN policy permits long installation times but imposes restrictions on the
+  time consumed by examples and unit tests that are much shorter than the time 
+  that it takes to compile even a simple Stan program. Thus, it is only possible
+  to adequately test your package if it has pre-compiled Stan programs.
+* Pre-compiled Stan programs can use custom C++ functions.  
+
+To provide flexibility to users, your Stan programs can include branching logic 
+(conditional statements) so that even with a small number of .stan files you can still 
+allow for many different specifications to made by the user (see the .stan files in
+[__rstanarm__](https://github.com/stan-dev/rstanarm/tree/master/src/stan_files) for 
 examples).
 
 * Use best practices for Stan code. If the models you intend to implement are


### PR DESCRIPTION
This is already necessary to call `rstan_package.skeleton` because rstanarm merged the 2.17 branch into master and so some files that it tries to download no longer exist on the master branch or are otherwise wrong. And CRAN is not going to accept new uploads for a couple of weeks starting tomorrow.