### PR TITLE
Switch to usethis::create_package 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,6 +34,8 @@ Suggests:
     knitr,
     devtools,
     roxygen2 (>= 6.0.1),
-    rmarkdown
+    rmarkdown,
+    rstudioapi,
+    usethis (>= 1.3.0)
 RoxygenNote: 6.0.1
 VignetteBuilder: knitr

--- a/man/rstan_package_skeleton.Rd
+++ b/man/rstan_package_skeleton.Rd
@@ -4,43 +4,41 @@
 \alias{rstan_package_skeleton}
 \title{Create the skeleton of a new \R package with Stan programs}
 \usage{
-rstan_package_skeleton(name = "anRpackage", list = character(),
-  environment = .GlobalEnv, path = ".", force = FALSE,
-  code_files = character(), stan_files = character(), travis = TRUE)
+rstan_package_skeleton(path, fields = getOption("devtools.desc"),
+  rstudio = TRUE, open = TRUE, stan_files = character(), travis = TRUE)
 }
 \arguments{
-\item{name, list, environment, path, force, code_files}{Same as
-\code{\link[utils]{package.skeleton}}.}
+\item{path}{A relative or absolute path to the new package to be created
+(terminating in the package name).}
+
+\item{fields, rstudio, open}{See \code{usethis::create_package}.}
 
 \item{stan_files}{A character vector with paths to \code{.stan} files to
 include in the package (these files will be included in the
-\code{src/stan_files} directory). Otherwise similar to the
-\code{code_files} argument.}
+\code{src/stan_files} directory). If not specified then the \code{.stan}
+files for the package can be manually placed into the appropriate directory
+later.}
 
 \item{travis}{Should a \code{.travis.yml} file be added to the package
 directory? Defaults to \code{TRUE}. The file has some settings already set
 to help with compilation issues, but we do not guarantee that it will work
-on \href{https://travis-ci.org/}{travis-ci}.}
+on \href{https://travis-ci.org/}{travis-ci} without manual adjustments.}
 }
 \description{
 \if{html}{\figure{stanlogo.png}{options: width="50px" alt="http://mc-stan.org/about/logo/"}}
   The \code{rstan_package_skeleton} function helps get you started developing
   \R packages that interface with Stan via the \pkg{rstan} package.
-  \code{rstan_package_skeleton} is very similar to
-  \code{\link[utils]{package.skeleton}} but is designed for source packages
-  that want to include Stan Programs that can be built into binary versions
-  (i.e., pre-compiled like \pkg{rstanarm}). See \strong{Details} for a few
-  ways that it differs from \code{package.skeleton}.
+  As of \pkg{rstantools} v1.5.0, \code{rstan_package_skeleton}
+  calls \code{usethis::create_package} (instead of \code{utils::package.skeleton})
+  and then makes necessary adjustments so that the package can include Stan Programs that can be built into binary versions
+  (i.e., pre-compiled like \pkg{rstanarm}).
 
   See the \strong{See Also} section below for links to recommendations for
   developers and a step by step walkthrough of what to do after running
   \code{rstan_package_skeleton}.
 }
-\details{
-This function first calls \code{\link[utils]{package.skeleton}} and
-  then adds the files listed in \code{stan_files} to the
-  \code{src/stan_files} directory. Finally, it downloads several files from
-  \pkg{rstanarm} package's
+\note{
+This function downloads several files from \pkg{rstanarm} package's
   \href{http://github.com/stan-dev/rstanarm}{GitHub repository} to facilitate
   building the resulting package. Note that \pkg{\link[rstanarm]{rstanarm}}
   is licensed under the GPL >= 3, so package builders who do not want to be
@@ -49,18 +47,6 @@ This function first calls \code{\link[utils]{package.skeleton}} and
   files is not the only thing impeding use of other licenses). Otherwise, it
   may be worth considering whether it would be easier to include your
   \code{.stan} programs and supporting \R code in the \pkg{rstanarm} package.
-
-  Unlike \code{package.skeleton}, \code{rstan_package_skeleton} also creates
-  a file in the \code{R/} directory called "\code{name}-package.R", where
-  \code{name} is the package name. In this file \code{rstan_package_skeleton}
-  writes lines (using \pkg{roxygen2} tags) for ensuring that some necessary
-  content makes it into the \code{NAMESPACE} file. Before terminating,
-  \code{rstan_package_skeleton} will run \code{roxygen2::roxygenise} so that
-  the NAMESPACE is created.
-
-  \code{rstan_package_skeleton} will also create an RStudio project file
-  for the package with a \code{.Rproj} extension. If not using RStudio
-  this file can be deleted or ignored.
 }
 \seealso{
 \itemize{

--- a/tests/testthat/test-rstan_package_skeleton.R
+++ b/tests/testthat/test-rstan_package_skeleton.R
@@ -2,10 +2,8 @@ context("rstan_package_skeleton")
 
 if (requireNamespace("rstan", quietly = TRUE)) { # FIXME when travis can install rstan again
   rstan_package_skeleton(
-    name = "testPackage",
-    path = tempdir(),
-    stan_files = test_path("test.stan"),
-    force = TRUE
+    path = file.path(tempdir(),"testPackage"),
+    stan_files = test_path("test.stan")
   )
   pkg_path <- file.path(tempdir(), "testPackage")
   pkg_files <- list.files(pkg_path, recursive = TRUE, all.files = TRUE)
@@ -16,11 +14,9 @@ if (requireNamespace("rstan", quietly = TRUE)) { # FIXME when travis can install
 
   test_that("package directory has required structure", {
     nms <- c("DESCRIPTION", "inst", "man", "NAMESPACE", "R",
-             "Read-and-delete-me", "src", "tools", "testPackage.Rproj")
+             "Read-and-delete-me", "src", "tools")
     ans <- list.files(pkg_path)
-    if ("data" %in% ans) {
-      nms <- c(nms, "data")
-    }
+    cat(ans, sep = "\n")
     expect_equal(sort(nms), sort(ans))
   })
   test_that(".travis.yml file included", {
@@ -48,31 +44,39 @@ if (requireNamespace("rstan", quietly = TRUE)) { # FIXME when travis can install
   test_that("messages are generated", {
     expect_message(
       rstan_package_skeleton(
-        name = "testPackage2",
-        path = tempdir(),
-        stan_files = test_path("test.stan"),
-        force = TRUE
+        path = file.path(tempdir(),"testPackage2"),
+        stan_files = test_path("test.stan")
       ),
       regexp = "Creating package skeleton for package: testPackage2"
     )
     expect_message(
       rstan_package_skeleton(
-        name = "testPackage3",
-        path = tempdir(),
-        stan_files = c("test.stan"),
-        force = TRUE
+        path = file.path(tempdir(),"testPackage3"),
+        stan_files = test_path("test.stan")
       ),
-      regexp = "Finished skeleton for package: testPackage3"
+      regexp = "Running usethis::create_package"
+    )
+    expect_message(
+      rstan_package_skeleton(
+        path = file.path(tempdir(),"testPackage4"),
+        stan_files = c("test.stan")
+      ),
+      regexp = "Finished skeleton for package: testPackage4"
+    )
+    expect_output(
+      rstan_package_skeleton(
+        path = file.path(tempdir(),"testPackage5"),
+        stan_files = c("test.stan")
+      ),
+      regexp = "Changing active project to testPackage5"
     )
   })
 
   test_that("error if stan_files specified incorrectly", {
     expect_error(
       rstan_package_skeleton(
-        name = "testPackage4",
-        path = tempdir(),
-        stan_files = c("test"),
-        force = TRUE
+        path = file.path(tempdir(),"testPackage6"),
+        stan_files = c("test")
       ),
       regexp = "must end with a '.stan' extension",
       fixed = TRUE
@@ -80,10 +84,8 @@ if (requireNamespace("rstan", quietly = TRUE)) { # FIXME when travis can install
 
     expect_error(
       rstan_package_skeleton(
-        name = "testPackage4",
-        path = tempdir(),
-        stan_files = c("test.stan", "test"),
-        force = TRUE
+        path = file.path(tempdir(),"testPackage7"),
+        stan_files = c("test.stan", "test")
       ),
       regexp = "must end with a '.stan' extension",
       fixed = TRUE

--- a/vignettes/minimal-rstan-package.Rmd
+++ b/vignettes/minimal-rstan-package.Rmd
@@ -31,42 +31,40 @@ that fits a simple linear regression. Before continuing, we recommend that you f
 
 To start off, we use `rstan_package_skeleton` to initialise a bare-bones
 package directory. The name of our demo package will be __rstanlm__; it will fit
-a simple linear regression model using Stan.
+a simple linear regression model using Stan. 
 
 ```{r, eval=FALSE}
 library("rstantools")
-rstan_package_skeleton(name = 'rstanlm')
+rstan_package_skeleton(path = 'rstanlm')
 ```
-```{r, results='hold', echo=FALSE,warning=FALSE}
+```{r, echo=FALSE,warning=FALSE}
 library("rstantools")
-if (file.exists("rstanlm")) {
-  unlink("rstanlm", recursive = TRUE)
-}
-rstan_package_skeleton(name = 'rstanlm')
+td <- tempdir()
+PATH <- file.path(td, "rstanlm")
+rstan_package_skeleton(path = PATH, rstudio=FALSE, open=FALSE)
 ```
-
 
 If we had existing `.stan` files to include with the package we could use the 
 optional `stan_files` argument to `rstan_package_skeleton` to include them. 
 Another option, which we'll use below, is to add the Stan files once the 
 basic structure of the package is in place. 
 
-The newly created package directory has the name of the package and 
-its contents are:
+We can now set the new working directory to the new package directory and view the contents. (Note: if using RStudio then by default the newly created project for the package will be opened in a new session and you will not need the call to `setwd()`.)
+
 
 ```{r, eval=FALSE}
 setwd("rstanlm")
 list.files(all.files = TRUE)
 ```
 ```{r, echo=FALSE}
-list.files("rstanlm", all.files = TRUE)
+list.files(PATH, all.files = TRUE)
 ```
 
 ```{r, eval=FALSE}
 file.show("DESCRIPTION")
 ```
 ```{r, echo=FALSE}
-DES <- readLines("rstanlm/DESCRIPTION")
+DES <- readLines(file.path(PATH, "DESCRIPTION"))
 cat(DES, sep = "\n")
 ```
 Some of the sections in the `DESCRIPTION` file need to be edited by hand
@@ -85,7 +83,7 @@ important instructions about customizing your package:
 file.show("Read-and-delete-me")
 ```
 ```{r, echo=FALSE}
-cat(readLines("rstanlm/Read-and-delete-me"), sep = "\n")
+cat(readLines(file.path(PATH, "Read-and-delete-me")), sep = "\n")
 ```
 
 You can move this file out of the directory, delete it, or list it in the
@@ -95,7 +93,7 @@ You can move this file out of the directory, delete it, or list it in the
 file.remove('Read-and-delete-me')
 ```
 ```{r, echo=FALSE}
-file.remove('rstanlm/Read-and-delete-me')
+file.remove(file.path(PATH, 'Read-and-delete-me'))
 ```
 
 
@@ -144,7 +142,7 @@ model {
   y ~ normal(intercept + beta * x, sigma);
 }
 "
-cat(stan_prog, file = "rstanlm/src/stan_files/lm.stan")
+cat(stan_prog, file = file.path(PATH, "src", "stan_files", "lm.stan"))
 ```
 
 The `src/stan_files` subdirectory can contain additional Stan programs if
@@ -193,7 +191,7 @@ lm_stan <- function(x, y) {
   return(out)
 }
 "
-cat(Rcode, file = file.path("rstanlm", "R", "lm_stan.R"))
+cat(Rcode, file = file.path(PATH, "R", "lm_stan.R"))
 ```
 
 The top-level package file `R/rstanlm-package.R` has already been created by
@@ -204,7 +202,7 @@ of our package:
 file.show(file.path("R", "rstanlm-package.R"))
 ```
 ```{r, echo=FALSE}
-cat(readLines(file.path("rstanlm", "R", "rstanlm-package.R")), sep = "\n")
+cat(readLines(file.path(PATH, "R", "rstanlm-package.R")), sep = "\n")
 ```
 
 The description section needs to be manually edited but the necessary
@@ -221,7 +219,7 @@ To update the `NAMESPACE` file and the rest of the documentation to include
 roxygen2::roxygenise(clean=TRUE)
 ```
 ```{r, echo=FALSE}
-roxygen2::roxygenise('rstanlm', clean=TRUE)
+roxygen2::roxygenise(PATH, clean=TRUE)
 ```
 
 
@@ -233,7 +231,7 @@ Finally, the package can be installed:
 devtools::install(local=FALSE)
 ```
 ```{r,echo=FALSE, results="hide"}
-devtools::load_all("rstanlm", recompile=TRUE)
+devtools::load_all(PATH, recompile=TRUE)
 ```
 
 The argument `local=FALSE` is necessary if you want to recompile the Stan
@@ -252,7 +250,7 @@ print(fit)
 ```
 
 ```{r, echo=FALSE}
-unlink("rstanlm", recursive = TRUE)
+unlink(PATH, recursive = TRUE)
 ```
 
 ## Links


### PR DESCRIPTION
Closes #25 

@bgoodri This PR gets rid of calling `utils::package.skeleton` inside of `rstan_package_skeleton` and replaces it with Hadley's much friendlier `usethis::create_package`. It also updates @sieste's step-by-step vignette to create the rstanlm package in a temporary directory. 