### PR TITLE
change devtools::install argument from local to quick

### DIFF
--- a/R/rstan_package_skeleton.R
+++ b/R/rstan_package_skeleton.R
@@ -273,8 +273,8 @@ use_read_and_delete_me <- function(pkg_dir) {
     "* You can put into src/stan_files/chunks any file that is needed by any .stan file in src/stan_files, ",
     "* You can put into inst/include any C++ files that are needed by any .stan file in src/stan_files, ",
     "but be sure to #include your C++ files in inst/include/meta_header.hpp",
-    "* While developing your package use devtools::install('.', local=FALSE) ",
-    "to reinstall the package AND recompile Stan programs, or set local=TRUE to skip the recompilation.",
+    "* While developing your package use devtools::install('.', quick=FALSE) ",
+    "to reinstall the package AND recompile Stan programs, or set quick=TRUE to skip the recompilation.",
     file = file.path(pkg_dir, "Read-and-delete-me"),
     sep = "\n",
     append = FALSE

--- a/vignettes/minimal-rstan-package.Rmd
+++ b/vignettes/minimal-rstan-package.Rmd
@@ -228,15 +228,15 @@ roxygen2::roxygenise(PATH, clean=TRUE)
 Finally, the package can be installed:
 
 ```{r,eval=FALSE}
-devtools::install(local=FALSE)
+devtools::install(quick=FALSE)
 ```
 ```{r,echo=FALSE, results="hide"}
 devtools::load_all(PATH, recompile=TRUE)
 ```
 
-The argument `local=FALSE` is necessary if you want to recompile the Stan
+The argument `quick=FALSE` is necessary if you want to recompile the Stan
 models. If you only made a small change to the R code or the documentation, you
-can set `local=TRUE` to speed up the process.
+can set `quick=TRUE` to speed up the process.
 
 The package can now be loaded and used like any other R package:
 


### PR DESCRIPTION
devtools::install() previously had a "local" argument that could be used to re-build a package without compiling Stan code. The arguments have changed (as of devtools version 2.0.0?), and "quick" is now the relevant argument.