### PR TITLE
Use markdown in roxygen documentation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,3 +40,4 @@ Suggests:
     rstudioapi
 RoxygenNote: 6.1.1
 VignetteBuilder: knitr
+Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ LazyData: true
 SystemRequirements: pandoc, C++14
 Imports: stats, utils, Rcpp (>= 0.12.16), desc
 Suggests:
-    bayesplot (>= 1.5.0),
+    bayesplot (>= 1.7.0),
     rstan (>= 2.17.2),
     rstanarm (>= 2.17.4),
     shinystan (>= 2.4.0),

--- a/R/bayes_R2.R
+++ b/R/bayes_R2.R
@@ -1,11 +1,9 @@
-
-
 #' Generic function and default method for Bayesian R-squared
 #'
 #' Generic function and default method for Bayesian version of R-squared for
 #' regression models. A generic for LOO-adjusted R-squared is also provided. See
-#' the `bayes_R2.stanreg` method in the \pkg{\link[rstanarm]{rstanarm}} package
-#' for an example of defining a method.
+#' the [bayes_R2.stanreg()][rstanarm::bayes_R2.stanreg] method in the
+#' \pkg{rstanarm} package for an example of defining a method.
 #'
 #' @export
 #' @template args-object

--- a/R/bayes_R2.R
+++ b/R/bayes_R2.R
@@ -4,27 +4,27 @@
 #'
 #' Generic function and default method for Bayesian version of R-squared for
 #' regression models. A generic for LOO-adjusted R-squared is also provided. See
-#' \code{bayes_R2.stanreg} in the \pkg{\link[rstanarm]{rstanarm}} package for an
-#' example of defining a method.
+#' the `bayes_R2.stanreg` method in the \pkg{\link[rstanarm]{rstanarm}} package
+#' for an example of defining a method.
 #'
 #' @export
 #' @template args-object
 #' @template args-dots
 #'
-#' @return \code{bayes_R2} and \code{loo_R2} methods should return a vector of
+#' @return `bayes_R2()` and `loo_R2()` methods should return a vector of
 #'   length equal to the posterior sample size.
 #'
-#'   The default \code{bayes_R2} method just takes \code{object} to be a matrix of y-hat values
-#'   (one column per observation, one row per posterior draw) and \code{y} to be
-#'   a vector with length equal to \code{ncol(object)}.
+#'   The default `bayes_R2()` method just takes `object` to be a matrix of y-hat
+#'   values (one column per observation, one row per posterior draw) and `y` to
+#'   be a vector with length equal to `ncol(object)`.
 #'
 #'
 #' @references
 #' Andrew Gelman, Ben Goodrich, Jonah Gabry, and Aki Vehtari (2018). R-squared
-#' for Bayesian regression models. \emph{The American Statistician}, to appear.
+#' for Bayesian regression models. *The American Statistician*, to appear.
 #' DOI: 10.1080/00031305.2018.1549100.
-#' (\href{http://www.stat.columbia.edu/~gelman/research/published/bayes_R2_v3.pdf}{Preprint},
-#' \href{https://avehtari.github.io/bayes_R2/bayes_R2.html}{Notebook})
+#' ([Preprint](http://www.stat.columbia.edu/~gelman/research/published/bayes_R2_v3.pdf),
+#' [Notebook](https://avehtari.github.io/bayes_R2/bayes_R2.html))
 #'
 #'
 #' @template seealso-rstanarm-pkg
@@ -36,8 +36,8 @@ bayes_R2 <- function(object, ...) {
 
 #' @rdname bayes_R2
 #' @export
-#' @param y For the default method, a vector of \eqn{y} values the same length
-#'   as the number of columns in the matrix used as \code{object}.
+#' @param y For the default method, a vector of `y` values the same length
+#'   as the number of columns in the matrix used as `object`.
 #'
 #' @importFrom stats var
 #'

--- a/R/init_cpp.R
+++ b/R/init_cpp.R
@@ -17,11 +17,11 @@
 
 #' Register functions implemented in C++
 #'
-#' If you set up your package using \code{rstan_package_skeleton} before
-#' version \code{1.2.1} of \pkg{rstantools} it may be necessary for you to call
-#' this function yourself in order to pass \code{R CMD check} in \R \code{>=
-#' 3.4}. If you used \code{rstan_package_skeleton} in \pkg{rstantools} version
-#' \code{1.2.1} or later then this has already been done automatically.
+#' If you set up your package using `rstan_package_skeleton()` before
+#' version `1.2.1` of \pkg{rstantools} it may be necessary for you to call
+#' this function yourself in order to pass `R CMD check` in \R
+#' `>= 3.4`. If you used `rstan_package_skeleton()` in \pkg{rstantools} version
+#' `1.2.1` or later then this has already been done automatically.
 #'
 #' @export
 #' @param name The name of your package as a string.
@@ -29,7 +29,7 @@
 #'   not specified it is assumed that this is already the current working
 #'   directory.
 #' @return This function is only called for its side effect of writing the
-#'   necessary \code{init.cpp} file to the package's \code{src/} directory.
+#'   necessary `init.cpp` file to the package's `src/` directory.
 #'
 init_cpp <- function(name, path) {
   file <- file.path("src", "init.cpp")

--- a/R/log_lik.R
+++ b/R/log_lik.R
@@ -1,9 +1,9 @@
 #' Generic function for pointwise log-likelihood
 #'
-#' We define a new function \code{log_lik} rather than a
+#' We define a new function `log_lik()` rather than a
 #' \code{\link[stats]{logLik}} method because (in addition to the conceptual
-#' difference) the documentation for \code{logLik} states that the return value
-#' will be a single number, whereas \code{log_lik} returns a matrix. See
+#' difference) the documentation for `logLik()` states that the return value
+#' will be a single number, whereas `log_lik()` returns a matrix. See
 #' \code{\link[rstanarm]{log_lik.stanreg}} in the \pkg{rstanarm} package for an
 #' example.
 #'
@@ -11,7 +11,7 @@
 #' @template args-object
 #' @template args-dots
 #'
-#' @return \code{log_lik} methods should return a \eqn{S} by \eqn{N} matrix,
+#' @return `log_lik()` methods should return a \eqn{S} by \eqn{N} matrix,
 #'   where \eqn{S} is the size of the posterior sample (the number of draws from
 #'   the posterior distribution) and \eqn{N} is the number of data points.
 #'

--- a/R/log_lik.R
+++ b/R/log_lik.R
@@ -1,11 +1,11 @@
 #' Generic function for pointwise log-likelihood
 #'
 #' We define a new function `log_lik()` rather than a
-#' \code{\link[stats]{logLik}} method because (in addition to the conceptual
+#' [stats::logLik()] method because (in addition to the conceptual
 #' difference) the documentation for `logLik()` states that the return value
 #' will be a single number, whereas `log_lik()` returns a matrix. See
-#' \code{\link[rstanarm]{log_lik.stanreg}} in the \pkg{rstanarm} package for an
-#' example.
+#' the [log_lik.stanreg()][rstanarm::log_lik.stanreg] method in the
+#' \pkg{rstanarm} package for an example of defining a method.
 #'
 #' @export
 #' @template args-object

--- a/R/loo-functions.R
+++ b/R/loo-functions.R
@@ -7,10 +7,10 @@
 #' @template args-object
 #' @template args-dots
 #'
-#' @return \code{loo_predict}, \code{loo_linpred}, and \code{loo_pit}
+#' @return `loo_predict()`, `loo_linpred()`, and `loo_pit()`
 #'   (probability integral transform) methods should return a vector with length
 #'   equal to the number of observations in the data.
-#'   \code{loo_predictive_interval} methods should return a two-column matrix
+#'   `loo_predictive_interval()` methods should return a two-column matrix
 #'   formatted in the same way as for \code{\link{predictive_interval}}.
 #'
 #' @template seealso-rstanarm-pkg
@@ -43,12 +43,10 @@ loo_pit <- function(object, ...) {
 
 #' @rdname loo-prediction
 #' @export
-#' @param y For the default method of \code{loo_pit}, a vector of \eqn{y} values
-#'   the same length as the number of columns in the matrix used as
-#'   \code{object}.
-#' @param lw For the default method of \code{loo_pit}, a matrix of log-weights
-#'   of the same length as the number of columns in the matrix used as
-#'   \code{object}.
+#' @param y For the default method of `loo_pit()`, a vector of `y` values the
+#'   same length as the number of columns in the matrix used as `object`.
+#' @param lw For the default method of `loo_pit()`, a matrix of log-weights of
+#'   the same length as the number of columns in the matrix used as `object`.
 #'
 loo_pit.default <- function(object, y, lw, ...) {
   if (!is.matrix(object))

--- a/R/loo-functions.R
+++ b/R/loo-functions.R
@@ -1,6 +1,6 @@
 #' Generic functions for LOO predictions
 #'
-#' See the methods in the \pkg{\link[rstanarm]{rstanarm}} package for examples.
+#' See the methods in the \pkg{rstanarm} package for examples.
 #'
 #' @name loo-prediction
 #'
@@ -11,7 +11,7 @@
 #'   (probability integral transform) methods should return a vector with length
 #'   equal to the number of observations in the data.
 #'   `loo_predictive_interval()` methods should return a two-column matrix
-#'   formatted in the same way as for \code{\link{predictive_interval}}.
+#'   formatted in the same way as for [predictive_interval()].
 #'
 #' @template seealso-rstanarm-pkg
 #' @template seealso-vignettes

--- a/R/posterior_interval.R
+++ b/R/posterior_interval.R
@@ -2,9 +2,8 @@
 #'
 #' These intervals are often referred to as credible intervals, but we use the
 #' term uncertainty intervals to highlight the fact that wider intervals
-#' correspond to greater uncertainty. See
-#' \code{\link[rstanarm]{posterior_interval.stanreg}} in the
-#' \pkg{\link[rstanarm]{rstanarm}} package for an example.
+#' correspond to greater uncertainty. See [rstanarm::posterior_interval.stanreg()]
+#' in the \pkg{rstanarm} package for an example.
 #'
 #' @export
 #' @template args-object

--- a/R/posterior_interval.R
+++ b/R/posterior_interval.R
@@ -12,17 +12,17 @@
 #' @param prob A number \eqn{p \in (0,1)}{p (0 < p < 1)} indicating the desired
 #'   probability mass to include in the intervals.
 #'
-#' @return \code{posterior_interval} methods should return a matrix with two
+#' @return `posterior_interval()` methods should return a matrix with two
 #'   columns and as many rows as model parameters (or a subset of parameters
-#'   specified by the user). For a given value of \code{prob}, \eqn{p}, the
+#'   specified by the user). For a given value of `prob`, \eqn{p}, the
 #'   columns correspond to the lower and upper \eqn{100p}\% interval limits and
 #'   have the names \eqn{100\alpha/2}\% and \eqn{100(1 - \alpha/2)}\%, where
-#'   \eqn{\alpha = 1-p}. For example, if \code{prob=0.9} is specified (a
-#'   \eqn{90}\% interval), then the column names would be \code{"5\%"} and
-#'   \code{"95\%"}, respectively.
+#'   \eqn{\alpha = 1-p}. For example, if `prob=0.9` is specified (a
+#'   \eqn{90}\% interval), then the column names would be `"5%"` and
+#'   `"95%"`, respectively.
 #'
-#'   The default method just takes \code{object} to be a matrix (one column per
-#'   parameter) and computes quantiles, with \code{prob} defaulting to 0.9.
+#'   The default method just takes `object` to be a matrix (one column per
+#'   parameter) and computes quantiles, with `prob` defaulting to `0.9`.
 #'
 #' @template seealso-rstanarm-pkg
 #' @template seealso-vignettes

--- a/R/posterior_linpred.R
+++ b/R/posterior_linpred.R
@@ -2,9 +2,8 @@
 #' predictor
 #'
 #' Extract the posterior draws of the linear predictor, possibly transformed by
-#' the inverse-link function. See
-#' \code{\link[rstanarm]{posterior_linpred.stanreg}} in the
-#' \pkg{\link[rstanarm]{rstanarm}} package for an example.
+#' the inverse-link function. See [rstanarm::posterior_linpred.stanreg()] in the
+#' \pkg{rstanarm} package for an example.
 #'
 #' @export
 #' @template args-object

--- a/R/posterior_linpred.R
+++ b/R/posterior_linpred.R
@@ -10,9 +10,9 @@
 #' @template args-object
 #' @template args-dots
 #' @param transform Should the linear predictor be transformed using the
-#'   inverse-link function? The default is \code{FALSE}, in which case the
+#'   inverse-link function? The default is `FALSE`, in which case the
 #'   untransformed linear predictor is returned.
-#' @return \code{posterior_linpred} methods should return a \eqn{D} by \eqn{N}
+#' @return `posterior_linpred()` methods should return a \eqn{D} by \eqn{N}
 #'   matrix, where \eqn{D} is the number of draws from the posterior
 #'   distribution distribution and \eqn{N} is the number of data points.
 #'

--- a/R/posterior_predict.R
+++ b/R/posterior_predict.R
@@ -7,7 +7,7 @@
 #' @export
 #' @template args-object
 #' @template args-dots
-#' @return \code{posterior_predict} methods should return a \eqn{D} by \eqn{N}
+#' @return `posterior_predict()` methods should return a \eqn{D} by \eqn{N}
 #'   matrix, where \eqn{D} is the number of draws from the posterior predictive
 #'   distribution and \eqn{N} is the number of data points being predicted per
 #'   draw.

--- a/R/posterior_predict.R
+++ b/R/posterior_predict.R
@@ -1,8 +1,8 @@
 #' Generic function for drawing from the posterior predictive distribution
 #'
 #' Draw from the posterior predictive distribution of the outcome. See
-#' \code{\link[rstanarm]{posterior_predict.stanreg}} in the
-#' \pkg{\link[rstanarm]{rstanarm}} package for an example.
+#' [rstanarm::posterior_predict.stanreg()] in the \pkg{rstanarm} package for an
+#' example.
 #'
 #' @export
 #' @template args-object

--- a/R/predictive_error.R
+++ b/R/predictive_error.R
@@ -9,13 +9,13 @@
 #' @export
 #' @template args-object
 #' @template args-dots
-#' @return \code{predictive_error} methods should return a \eqn{D} by \eqn{N}
+#' @return `predictive_error()` methods should return a \eqn{D} by \eqn{N}
 #'   matrix, where \eqn{D} is the number of draws from the posterior predictive
 #'   distribution and \eqn{N} is the number of data points being predicted per
 #'   draw.
 #'
-#'   The default method just takes \code{object} to be a matrix and \code{y}
-#'   to be a vector.
+#'   The default method just takes `object` to be a matrix and `y` to be a
+#'   vector.
 #'
 #' @template seealso-rstanarm-pkg
 #' @template seealso-vignettes
@@ -36,8 +36,8 @@ predictive_error <- function(object, ...) {
 
 #' @rdname predictive_error
 #' @export
-#' @param y For the default method, a vector of \eqn{y} values the same length
-#'   as the number of columns in the matrix used as \code{object}.
+#' @param y For the default method, a vector of `y` values the same length as
+#'   the number of columns in the matrix used as `object`.
 predictive_error.default <- function(object, y, ...) {
   if (!is.matrix(object))
     stop("For the default method 'object' should be a matrix.")

--- a/R/predictive_error.R
+++ b/R/predictive_error.R
@@ -3,8 +3,8 @@
 #' Generic function and default method for computing predictive errors
 #' \eqn{y - y^{rep}}{y - yrep} (in-sample, for observed \eqn{y}) or
 #' \eqn{y - \tilde{y}}{y - ytilde} (out-of-sample, for new or held-out \eqn{y}).
-#' See \code{\link[rstanarm]{predictive_error.stanreg}} in the
-#' \pkg{\link[rstanarm]{rstanarm}} package for an example.
+#' See [rstanarm::predictive_error.stanreg()] in the \pkg{rstanarm} package for
+#' an example.
 #'
 #' @export
 #' @template args-object

--- a/R/predictive_interval.R
+++ b/R/predictive_interval.R
@@ -1,7 +1,7 @@
 #' Generic function for predictive intervals
 #'
-#' See \code{\link[rstanarm]{predictive_interval.stanreg}} in the
-#' \pkg{\link[rstanarm]{rstanarm}} package for an example.
+#' See [rstanarm::predictive_interval.stanreg()] in the \pkg{rstanarm} package
+#' for an example.
 #'
 #' @export
 #' @template args-object

--- a/R/predictive_interval.R
+++ b/R/predictive_interval.R
@@ -9,16 +9,16 @@
 #' @param prob A number \eqn{p \in (0,1)}{p (0 < p < 1)} indicating the desired
 #'   probability mass to include in the intervals.
 #'
-#' @return \code{predictive_interval} methods should return a matrix with two
+#' @return `predictive_interval()` methods should return a matrix with two
 #'   columns and as many rows as data points being predicted. For a given value
-#'   of \code{prob}, \eqn{p}, the columns correspond to the lower and upper
+#'   of `prob`, \eqn{p}, the columns correspond to the lower and upper
 #'   \eqn{100p}\% interval limits and have the names \eqn{100\alpha/2}\% and
 #'   \eqn{100(1 - \alpha/2)}\%, where \eqn{\alpha = 1-p}. For example, if
-#'   \code{prob=0.9} is specified (a \eqn{90}\% interval), then the column names
-#'   would be \code{"5\%"} and \code{"95\%"}, respectively.
+#'   `prob=0.9` is specified (a \eqn{90}\% interval), then the column names
+#'   would be `"5%"` and `"95%"`, respectively.
 #'
-#'   The default method just takes \code{object} to be a matrix and computes
-#'   quantiles, with \code{prob} defaulting to 0.9.
+#'   The default method just takes `object` to be a matrix and computes
+#'   quantiles, with `prob` defaulting to `0.9`.
 #'
 #' @template seealso-rstanarm-pkg
 #' @template seealso-vignettes
@@ -46,14 +46,14 @@ predictive_interval.default <- function(object, prob = 0.9, ...) {
 
 # internal ----------------------------------------------------------------
 
-# Compute central intervals
-#
+#' Compute central intervals
+#'
+#' @noRd
+#' @param object A numeric matrix
+#' @param prob Probability mass to include in intervals (in (0,1))
+#' @return See above.
+#'
 #' @importFrom stats quantile
-#
-# @param object A numeric matrix
-# @param prob Probability mass to include in intervals (in (0,1))
-# @return See @return above.
-#
 .central_intervals <- function(object, prob) {
   stopifnot(is.matrix(object))
   if (length(prob) != 1L || prob <= 0 || prob >= 1)

--- a/R/prior_summary.R
+++ b/R/prior_summary.R
@@ -7,12 +7,12 @@
 #' @template args-object
 #' @template args-dots
 #'
-#' @return \code{prior_summary} methods should return an object containing
+#' @return `prior_summary()` methods should return an object containing
 #'   information about the prior distribution(s) used for the given model.
 #'   The structure of this object will depend on the method.
 #'
-#'   The default method just returns \code{object$prior.info}, which is
-#'   \code{NULL} if there is no \code{'prior.info'} element.
+#'   The default method just returns `object$prior.info`, which is
+#'   `NULL` if there is no `'prior.info'` element.
 #'
 #' @template seealso-rstanarm-pkg
 #' @template seealso-vignettes

--- a/R/prior_summary.R
+++ b/R/prior_summary.R
@@ -1,7 +1,7 @@
 #' Generic function for extracting information about prior distributions
 #'
-#' See \code{\link[rstanarm]{prior_summary.stanreg}} in the
-#' \pkg{\link[rstanarm]{rstanarm}} package for an example.
+#' See [rstanarm::prior_summary.stanreg()] in the \pkg{rstanarm} package for an
+#' example.
 #'
 #' @export
 #' @template args-object

--- a/R/rstan_config.R
+++ b/R/rstan_config.R
@@ -15,21 +15,22 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
+
 #' Configure system files for compiling Stan source code
 #'
-#' Creates or update package-specific system files to compile \code{.stan} model
-#' files found in \code{inst/stan}.
+#' Creates or update package-specific system files to compile `.stan` model
+#' files found in `inst/stan`.
 #'
 #' @export
 #' @template args-pkgdir
 #' @details The Stan source files for the package should be stored in:
 #' \itemize{
-#'   \item \code{inst/stan} for \code{.stan} files containing instructions to
-#'   build a \code{stanmodel} object.
-#'   \item \code{inst/stan/any_subfolder} for files to be included via the
-#'   \code{#include "/my_subfolder/mylib.stan"} directive.
-#'   \item \code{inst/stan/any_subfolder} for a \code{license.stan} file.
-#'   \item \code{inst/include} for the \code{stan_meta_header.hpp} file, to be
+#'   \item `inst/stan` for `.stan` files containing instructions to
+#'   build a `stanmodel` object.
+#'   \item `inst/stan/any_subfolder` for files to be included via the
+#'   `#include "/my_subfolder/mylib.stan"` directive.
+#'   \item `inst/stan/any_subfolder` for a `license.stan` file.
+#'   \item `inst/include` for the `stan_meta_header.hpp` file, to be
 #'   used for directly interacting with the Stan C++ libraries.
 #' }
 #'

--- a/R/rstan_create_package.R
+++ b/R/rstan_create_package.R
@@ -22,46 +22,45 @@
 #'
 #' @description
 #'   \if{html}{\figure{stanlogo.png}{options: width="25px" alt="https://mc-stan.org/about/logo/"}}
-#'   The \code{rstan_create_package} function helps get you started developing a
+#'   The `rstan_create_package()` function helps get you started developing a
 #'   new \R package that interfaces with Stan via the \pkg{rstan} package. First
-#'   the basic package structure is set up via \code{usethis::create_package}.
+#'   the basic package structure is set up via `usethis::create_package()`.
 #'   Then several adjustments are made so the package can include Stan programs
 #'   that can be built into binary versions (i.e., pre-compiled Stan C++ code).
 #'
-#'   The \strong{Details} section below describes the process and the
-#'   \strong{See Also} section provides links to recommendations for developers
+#'   The **Details** section below describes the process and the
+#'   **See Also** section provides links to recommendations for developers
 #'   and a step-by-step walk-through.
 #'
-#'   As of version \code{2.0.0} of \pkg{rstantools} the
-#'   \code{rstan_package_skeleton} function is defunct and only
-#'   \code{rstan_create_package} is supported.
+#'   As of version `2.0.0` of \pkg{rstantools} the
+#'   `rstan_package_skeleton()` function is defunct and only
+#'   `rstan_create_package()` is supported.
 #'
 #' @export
 #' @param path The path to the new package to be created (terminating in the
 #'   package name).
 #' @param fields,rstudio,open Same as \code{\link{usethis::create_package}}. See
 #'   the documentation for that function, especially the note in the
-#'   \strong{Description} section about the side effect of changing the active
+#'   **Description** section about the side effect of changing the active
 #'   project.
-#' @param stan_files A character vector with paths to \code{.stan} files to
-#'   include in the package.
+#' @param stan_files A character vector with paths to `.stan` files to include
+#'   in the package.
 #' @param roxygen Should \pkg{roxygen2} be used for documentation?  Defaults to
-#'   \code{TRUE}. If so, a file \code{R/{pkgname}-package.R} is added to the
-#'   package with roxygen tags for the required import lines. See the
-#'   \strong{Note} section below for advice specific to the latest versions of
-#'   \pkg{roxygen2}.
-#' @param travis Should a \code{.travis.yml} file be added to the package
-#'   directory? Defaults to \code{TRUE}.  While the file contains some presets
-#'   to help with compilation issues, at present it is not guaranteed to work on
-#'   \href{https://travis-ci.org/}{travis-ci} without manual adjustments.
+#'   `TRUE`. If so, a file `R/{pkgname}-package.R`` is added to the package with
+#'   roxygen tags for the required import lines. See the **Note** section below
+#'   for advice specific to the latest versions of \pkg{roxygen2}.
+#' @param travis Should a `.travis.yml` file be added to the package directory?
+#'   Defaults to `TRUE`.  While the file contains some presets to help with
+#'   compilation issues, at present it is not guaranteed to work on
+#'   [travis-ci](https://travis-ci.org/) without manual adjustments.
 #' @template args-license
 #' @template args-auto_config
 #'
 #' @details
 #' This function first creates a regular \R package using
-#' \code{usethis::create_package}, then adds the infrastructure required to
-#' compile and export \code{stanmodel} objects. In the package root directory,
-#' the user's Stan source code is located in:
+#' `usethis::create_package()`, then adds the infrastructure required to compile
+#' and export `stanmodel` objects. In the package root directory, the user's
+#' Stan source code is located in:
 #' \preformatted{
 #' inst/
 #'   |_stan/
@@ -69,9 +68,9 @@
 #'   |
 #'   |_include/
 #' }
-#' All \code{.stan} files containing instructions to build a \code{stanmodel}
-#' object must be placed in \code{inst/stan}.  Other \code{.stan} files go in
-#' any \code{stan/} subdirectory, to be invoked by Stan's \code{#include}
+#' All `.stan` files containing instructions to build a `stanmodel`
+#' object must be placed in `inst/stan`.  Other `.stan` files go in
+#' any `stan/` subdirectory, to be invoked by Stan's `#include`
 #' mechanism, e.g.,
 #' \preformatted{
 #' #include "include/mylib.stan"
@@ -79,36 +78,36 @@
 #' }
 #' See \pkg{rstanarm} for many examples.
 #'
-#' The folder \code{inst/include} is for all user C++ files associated with the
+#' The folder `inst/include` is for all user C++ files associated with the
 #' Stan programs.  In this folder, the only file to directly interact with the
-#' Stan C++ library is \code{stan_meta_header.hpp}; all other \code{#include}
+#' Stan C++ library is `stan_meta_header.hpp`; all other `#include`
 #' directives must be channeled through here.
 #'
 #' The final step of the package creation is to invoke
 #' \code{\link{rstan_config}}, which creates the following files for
 #' interfacing with Stan objects from \R:
 #' \itemize{
-#'   \item \code{src} contains the \code{stan_ModelName{.cc/.hpp}} pairs
-#'   associated with all \code{ModelName.stan} files in \code{inst/stan} which
-#'   define \code{stanmodel} objects.
-#'   \item \code{src/Makevars[.win]} which link to the \code{StanHeaders} and
-#'   Boost (\code{BH}) libraries.
-#'   \item \code{R/stanmodels.R} loads the C++ modules containing the
-#'   \code{stanmodel} class definitions, and assigns an \R instance of each
-#'   \code{stanmodel} object to a \code{stanmodels} list (with names
+#'   \item `src` contains the `stan_ModelName{.cc/.hpp}` pairs
+#'   associated with all `ModelName.stan` files in `inst/stan` which
+#'   define `stanmodel` objects.
+#'   \item `src/Makevars[.win]` which link to the `StanHeaders` and
+#'   Boost (`BH`) libraries.
+#'   \item `R/stanmodels.R` loads the C++ modules containing the
+#'   `stanmodel` class definitions, and assigns an \R instance of each
+#'   `stanmodel` object to a `stanmodels` list (with names
 #'   corresponding to the names of the Stan files).
 #' }
 #' @template details-auto_config
 #' @template details-license
 #' @details Authors willing to license their Stan programs of general interest
-#'   under the GPL are invited to contribute their \code{.stan} files and
+#'   under the GPL are invited to contribute their `.stan` files and
 #'   supporting \R code to the \pkg{rstanarm} package.
 #'
 #' @template section-running-stan
 #'
 #' @note For \pkg{devtools} users, because of changes in the latest versions of
-#'   \pkg{roxygen2} it may be necessary to run \code{pkgbuild::compile_dll()}
-#'   once before \code{devtools::document()} will work.
+#'   \pkg{roxygen2} it may be necessary to run `pkgbuild::compile_dll()`
+#'   once before `devtools::document()` will work.
 #'
 #' @seealso
 #' \itemize{

--- a/R/rstan_create_package.R
+++ b/R/rstan_create_package.R
@@ -39,7 +39,7 @@
 #' @export
 #' @param path The path to the new package to be created (terminating in the
 #'   package name).
-#' @param fields,rstudio,open Same as \code{\link{usethis::create_package}}. See
+#' @param fields,rstudio,open Same as [usethis::create_package()]. See
 #'   the documentation for that function, especially the note in the
 #'   **Description** section about the side effect of changing the active
 #'   project.
@@ -84,7 +84,7 @@
 #' directives must be channeled through here.
 #'
 #' The final step of the package creation is to invoke
-#' \code{\link{rstan_config}}, which creates the following files for
+#' [rstan_config()], which creates the following files for
 #' interfacing with Stan objects from \R:
 #' \itemize{
 #'   \item `src` contains the `stan_ModelName{.cc/.hpp}` pairs
@@ -110,13 +110,11 @@
 #'   once before `devtools::document()` will work.
 #'
 #' @seealso
-#' \itemize{
-#'   \item \code{\link{use_rstan}} for adding Stan functionality to an existing
-#'   \R package, \code{\link{rstan_config}} for updating an existing package
+#' * [use_rstan()] for adding Stan functionality to an existing
+#'   \R package and [rstan_config()] for updating an existing package
 #'   when its Stan files are changed.
-#'   \item \href{https://github.com/stan-dev/rstanarm}{The \pkg{rstanarm}
-#'   repository on GitHub.}
-#' }
+#' * The \pkg{rstanarm} package [repository](https://github.com/stan-dev/rstanarm)
+#'   on GitHub.
 #' @template seealso-vignettes
 #' @template seealso-get-help
 #' @template seealso-useR2016-video

--- a/R/rstan_create_package.R
+++ b/R/rstan_create_package.R
@@ -24,7 +24,7 @@
 #'   \if{html}{\figure{stanlogo.png}{options: width="25px" alt="https://mc-stan.org/about/logo/"}}
 #'   The `rstan_create_package()` function helps get you started developing a
 #'   new \R package that interfaces with Stan via the \pkg{rstan} package. First
-#'   the basic package structure is set up via `usethis::create_package()`.
+#'   the basic package structure is set up via [usethis::create_package()].
 #'   Then several adjustments are made so the package can include Stan programs
 #'   that can be built into binary versions (i.e., pre-compiled Stan C++ code).
 #'

--- a/R/rstantools-package.R
+++ b/R/rstantools-package.R
@@ -7,11 +7,11 @@
 #' @description
 #' \if{html}{
 #'   \figure{stanlogo.png}{options: width="50px" alt="mc-stan.org"}
-#'   \emph{Stan Development Team}
+#'   *Stan Development Team*
 #' }
 #'
 #' The \pkg{rstantools} package provides various tools for developers of \R
-#' packages interfacing with Stan (\url{https://mc-stan.org}), including
+#' packages interfacing with Stan (<https://mc-stan.org>), including
 #' functions to set up the required package structure, S3 generic methods to
 #' unify function naming across Stan-based \R packages, and vignettes with
 #' guidelines for developers. To get started building a package see

--- a/R/rstantools-package.R
+++ b/R/rstantools-package.R
@@ -7,8 +7,7 @@
 #' @description
 #' \if{html}{
 #'   \figure{stanlogo.png}{options: width="50px" alt="mc-stan.org"}
-#'   *Stan Development Team*
-#' }
+#' } *Stan Development Team*
 #'
 #' The \pkg{rstantools} package provides various tools for developers of \R
 #' packages interfacing with Stan (<https://mc-stan.org>), including

--- a/R/rstantools-package.R
+++ b/R/rstantools-package.R
@@ -15,7 +15,7 @@
 #' functions to set up the required package structure, S3 generic methods to
 #' unify function naming across Stan-based \R packages, and vignettes with
 #' guidelines for developers. To get started building a package see
-#' \code{\link{rstan_create_package}}.
+#' [rstan_create_package()].
 #'
 #' @template seealso-vignettes
 #' @template seealso-get-help

--- a/R/update_description.R
+++ b/R/update_description.R
@@ -1,29 +1,30 @@
-#' Update \code{DESCRIPTION} to include all packages required to compile Stan code.
+#' Update `DESCRIPTION` to include all packages required to compile Stan code.
 #'
+#' @noRd
 #' @param pkgdir Package root directory.
 #' @param auto_config Whether or not package should configure itself.  This
-#'   means importing \code{rstantools} for linking via \code{configure[.win]})
-#'   and setting \code{Biarch: true} in the \code{DESCRIPTION}.
+#'   means importing `rstantools` for linking via `configure[.win]`) and setting
+#'   `Biarch: true` in the `DESCRIPTION`.
 #' @param msg Whether or not to display a message if an attempt to update
-#'   \code{DESCRIPTION} is made.
+#'   `DESCRIPTION` is made.
 #'
-#' @return Whether or not \code{DESCRIPTION} file was modified.
+#' @return Whether or not `DESCRIPTION` file was modified.
 #'
 #' @details Sanitizes the package dependencies as follows:
 #' \itemize{
-#'   \item If \code{rstantools} dependency version is lower, don't update
+#'   \item If `rstantools` dependency version is lower, don't update
 #'   existing dependency.
-#'   \item If \code{rstantools} \code{Imports} dependency already exists in
-#'   \code{Depends}, keep the \code{Depends} package but increase version if
+#'   \item If `rstantools` `Imports` dependency already exists in
+#'   `Depends`, keep the `Depends` package but increase version if
 #'   needed.
 #' }
 #'
 #' Issues the following messages:
 #' \itemize{
-#'   \item If \code{auto_config = FALSE} and \code{rstantools} is imported.
-#'   \item If \code{auto_config = FALSE} and \code{Biarch: true}.
+#'   \item If `auto_config = FALSE` and `rstantools` is imported.
+#'   \item If `auto_config = FALSE` and `Biarch: true`.
 #' }
-#' @noRd
+#'
 .update_description <- function(pkgdir, auto_config = FALSE, msg = TRUE) {
   # current desc file
   desc_pkg <- desc::description$new(file.path(pkgdir, "DESCRIPTION"))

--- a/R/use_rstan.R
+++ b/R/use_rstan.R
@@ -18,9 +18,8 @@
 
 #' Add Stan infrastructure to an existing package
 #'
-#' Add Stan infrastructure to an existing \R package. To create a *new*
-#' package containing Stan programs use \code{\link{rstan_create_package}}
-#' instead.
+#' Add Stan infrastructure to an existing \R package. To create a *new* package
+#' containing Stan programs use [rstan_create_package()] instead.
 #'
 #' @template args-pkgdir
 #' @template args-license
@@ -28,30 +27,26 @@
 #'
 #' @details Prepares a package to compile and use Stan code by performing the
 #'   following steps:
-#' \enumerate{
-#'   \item Create `inst/stan` folder where all `.stan` files defining
+#' 1. Create `inst/stan` folder where all `.stan` files defining
 #'   Stan models should be stored.
-#'   \item Create `inst/stan/include` where optional `license.stan`
-#'   file is stored.
-#'   \item Create `inst/include/stan_meta_header.hpp` to include optional
-#'   header files used by Stan code.
-#'   \item Create `src` folder (if it doesn't exist) to contain the Stan
-#'   C++ code.
-#'   \item Create `R` folder (if it doesn't exist) to contain wrapper code
-#'   to expose Stan C++ classes to \R.
-#'   \item Update `DESCRIPTION` file to contain all needed dependencies to
-#'   compile Stan C++ code.
-#'   \item If `NAMESPACE` file is generic (i.e., created by
-#'   \code{\link{rstan_create_package}}), append `import(Rcpp, methods)`,
-#'   `importFrom(rstan, sampling)`, and `useDynLib` directives.  If
-#'   `NAMESPACE` is not generic, display message telling user what to add
-#'   to `NAMESPACE` for themselves.
-#' }
+#' 1. Create `inst/stan/include` where optional `license.stan` file is stored.
+#' 1. Create `inst/include/stan_meta_header.hpp` to include optional header
+#'   files used by Stan code.
+#' 1. Create `src` folder (if it doesn't exist) to contain the Stan C++ code.
+#' 1. Create `R` folder (if it doesn't exist) to contain wrapper code to expose
+#'   Stan C++ classes to \R.
+#' 1. Update `DESCRIPTION` file to contain all needed dependencies to compile
+#'   Stan C++ code.
+#' 1. If `NAMESPACE` file is generic (i.e., created by [rstan_create_package()]),
+#'   append `import(Rcpp, methods)`, `importFrom(rstan, sampling)`,
+#'   and `useDynLib` directives.  If `NAMESPACE` is not generic, display message
+#'   telling user what to add to `NAMESPACE` for themselves.
 #'
 #' @template details-auto_config
 #' @template section-running-stan
 #'
-#' @return Invisibly, whether or not any files or folders where created or modified.
+#' @return Invisibly, `TRUE` or `FALSE` indicating whether or not any files or
+#'   folders where created or modified.
 #'
 #' @export
 use_rstan <- function(pkgdir = ".", license = TRUE, auto_config = TRUE) {

--- a/R/use_rstan.R
+++ b/R/use_rstan.R
@@ -15,9 +15,10 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
+
 #' Add Stan infrastructure to an existing package
 #'
-#' Add Stan infrastructure to an existing \R package. To create a \emph{new}
+#' Add Stan infrastructure to an existing \R package. To create a *new*
 #' package containing Stan programs use \code{\link{rstan_create_package}}
 #' instead.
 #'
@@ -28,23 +29,23 @@
 #' @details Prepares a package to compile and use Stan code by performing the
 #'   following steps:
 #' \enumerate{
-#'   \item Create \code{inst/stan} folder where all \code{.stan} files defining
+#'   \item Create `inst/stan` folder where all `.stan` files defining
 #'   Stan models should be stored.
-#'   \item Create \code{inst/stan/include} where optional \code{license.stan}
+#'   \item Create `inst/stan/include` where optional `license.stan`
 #'   file is stored.
-#'   \item Create \code{inst/include/stan_meta_header.hpp} to include optional
+#'   \item Create `inst/include/stan_meta_header.hpp` to include optional
 #'   header files used by Stan code.
-#'   \item Create \code{src} folder (if it doesn't exist) to contain the Stan
+#'   \item Create `src` folder (if it doesn't exist) to contain the Stan
 #'   C++ code.
-#'   \item Create \code{R} folder (if it doesn't exist) to contain wrapper code
+#'   \item Create `R` folder (if it doesn't exist) to contain wrapper code
 #'   to expose Stan C++ classes to \R.
-#'   \item Update \code{DESCRIPTION} file to contain all needed dependencies to
+#'   \item Update `DESCRIPTION` file to contain all needed dependencies to
 #'   compile Stan C++ code.
-#'   \item If \code{NAMESPACE} file is generic (i.e., created by
-#'   \code{\link{rstan_create_package}}), append \code{import(Rcpp, methods)},
-#'   \code{importFrom(rstan, sampling)}, and \code{useDynLib} directives.  If
-#'   \code{NAMESPACE} is not generic, display message telling user what to add
-#'   to \code{NAMESPACE} for themselves.
+#'   \item If `NAMESPACE` file is generic (i.e., created by
+#'   \code{\link{rstan_create_package}}), append `import(Rcpp, methods)`,
+#'   `importFrom(rstan, sampling)`, and `useDynLib` directives.  If
+#'   `NAMESPACE` is not generic, display message telling user what to add
+#'   to `NAMESPACE` for themselves.
 #' }
 #'
 #' @template details-auto_config

--- a/man-roxygen/args-auto_config.R
+++ b/man-roxygen/args-auto_config.R
@@ -1,3 +1,2 @@
 #' @param auto_config Whether to automatically configure Stan functionality
-#'   whenever the package gets installed (see \strong{Details}). Defaults to
-#'   \code{TRUE}.
+#'   whenever the package gets installed (see **Details**). Defaults to `TRUE`.

--- a/man-roxygen/args-license.R
+++ b/man-roxygen/args-license.R
@@ -1,4 +1,4 @@
 #' @param license Logical or character; whether or not to paste the contents of
 #'   a \code{license.stan} file at the top of all Stan code, or path to such a
-#'   file.  If \code{TRUE} (the default) adds the \code{GPL (>= 3)} license (see
-#'   \strong{Details}).
+#'   file.  If `TRUE` (the default) adds the `GPL (>= 3)` license (see
+#'   **Details**).

--- a/man-roxygen/details-auto_config.R
+++ b/man-roxygen/details-auto_config.R
@@ -1,8 +1,7 @@
-#' @details When \code{auto_config = TRUE}, a \code{configure[.win]} file is
-#'   added to the package, calling \code{rstantools::\link{rstan_config}}
-#'   whenever the package is installed.  Consequently, the package must list
-#'   \code{rstantools} in the \code{DESCRIPTION} Imports field for this
-#'   mechanism to work.  Setting \code{auto_config = FALSE} removes the
-#'   package's dependency on \code{rstantools}.  However, the package then must
-#'   be manually configured by running \code{\link{rstan_config}} whenever
-#'   \code{stanmodel} files in \code{inst/stan} are added/removed/modified.
+#' @details When `auto_config = TRUE`, a `configure[.win]` file is added to the
+#'   package, calling [rstan_config()] whenever the package is installed.
+#'   Consequently, the package must list \pkg{rstantools} in the `DESCRIPTION`
+#'   Imports field for this mechanism to work.  Setting `auto_config = FALSE`
+#'   removes the package's dependency on \pkg{rstantools}, but the package then
+#'   must be manually configured by running [rstan_config()] whenever
+#'   `stanmodel` files in `inst/stan` are added, removed, or modified.

--- a/man-roxygen/details-license.R
+++ b/man-roxygen/details-license.R
@@ -3,6 +3,6 @@
 #'   >= 3, the same license applies to your package should you choose to
 #'   distribute it.  Even if you don't use \pkg{\link{rstantools}} to create
 #'   your package, it is likely that you will be linking to \pkg{\link{Rcpp}} to
-#'   export the Stan C++ \code{stanmodel} objects to \R.  Since
+#'   export the Stan C++ `stanmodel` objects to \R.  Since
 #'   \pkg{\link{Rcpp}} is released under GPL >= 2, the same license would apply
 #'   to your package upon distribution.

--- a/man-roxygen/section-running-stan.R
+++ b/man-roxygen/section-running-stan.R
@@ -1,8 +1,7 @@
-#' @section Using the pre-compiled Stan programs in your package:
-#'   The \code{stanmodel} objects corresponding to the Stan programs
-#'   included with your package are stored in a list called \code{stanmodels}.
-#'   To run one of the Stan programs from within an R function in your package
-#'   just pass the appropriate element of the \code{stanmodels} list to one of
-#'   the \pkg{rstan} functions for model fitting (e.g., \code{sampling}). For
-#'   example, for a Stan program "foo.stan" you would use
-#'   \code{rstan::sampling(stanmodels$foo, ...)}.
+#' @section Using the pre-compiled Stan programs in your package: The
+#'   `stanmodel` objects corresponding to the Stan programs included with your
+#'   package are stored in a list called `stanmodels`. To run one of the Stan
+#'   programs from within an R function in your package just pass the
+#'   appropriate element of the `stanmodels` list to one of the \pkg{rstan}
+#'   functions for model fitting (e.g., `sampling()`). For example, for a Stan
+#'   program `"foo.stan"` you would use `rstan::sampling(stanmodels$foo, ...)`.

--- a/man-roxygen/seealso-get-help.R
+++ b/man-roxygen/seealso-get-help.R
@@ -1,8 +1,4 @@
 #' @seealso
-#' \itemize{
-#'   \item After reading the guidelines for developers, if you have trouble
-#'   setting up your package let us know on the the
-#'   \href{https://discourse.mc-stan.org}{Stan Forums} or at
-#'   \href{https://github.com/stan-dev/rstantools/issues}{\pkg{rstantools} issue
-#'   tracker}.
-#' }
+#' * After reading the guidelines for developers, if you have trouble setting up
+#'   your package let us know on the the [Stan Forums](https://discourse.mc-stan.org)
+#'   or at the \pkg{rstantools} GitHub [issue tracker](https://github.com/stan-dev/rstantools/issues).

--- a/man-roxygen/seealso-rstanarm-pkg.R
+++ b/man-roxygen/seealso-rstanarm-pkg.R
@@ -1,6 +1,4 @@
 #' @seealso
-#' \itemize{
-#'   \item The \pkg{\link[rstanarm]{rstanarm}} package for example methods
-#'   (\href{https://CRAN.R-project.org/package=rstanarm}{CRAN},
-#'   \href{https://github.com/stan-dev/rstanarm}{GitHub}).
-#' }
+#' * The \pkg{\link[rstanarm]{rstanarm}} package for example methods
+#'   ([CRAN](https://CRAN.R-project.org/package=rstanarm),
+#'   [GitHub](https://github.com/stan-dev/rstanarm)).

--- a/man-roxygen/seealso-useR2016-video.R
+++ b/man-roxygen/seealso-useR2016-video.R
@@ -1,6 +1,3 @@
 #' @seealso
-#' \itemize{
-#'   \item The useR2016 presentation
-#'   \href{https://channel9.msdn.com/Events/useR-international-R-User-conferences/useR-International-R-User-2017-Conference/How-to-Use-RStan-to-Estimate-Models-in-External-R-Packages}{How
-#'   to Use (R)Stan to Estimate Models in External R Packages.}
-#' }
+#' * The useR2016 presentation
+#'   [How to Use (R)Stan to Estimate Models in External R Packages.](https://channel9.msdn.com/Events/useR-international-R-User-conferences/useR-International-R-User-2017-Conference/How-to-Use-RStan-to-Estimate-Models-in-External-R-Packages)

--- a/man-roxygen/seealso-vignettes.R
+++ b/man-roxygen/seealso-vignettes.R
@@ -1,7 +1,5 @@
 #' @seealso
-#' \itemize{
-#'   \item Guidelines and recommendations for developers of \R packages
+#' * Guidelines and recommendations for developers of \R packages
 #'   interfacing with Stan and a demonstration getting a simple package working
 #'   can be found in the vignettes included with \pkg{rstantools} and at
-#'   \url{https://mc-stan.org/rstantools/articles/}.
-#' }
+#'   [mc-stan.org/rstantools/articles](https://mc-stan.org/rstantools/articles/).

--- a/man/bayes_R2.Rd
+++ b/man/bayes_R2.Rd
@@ -32,8 +32,8 @@ be a vector with length equal to \code{ncol(object)}.
 \description{
 Generic function and default method for Bayesian version of R-squared for
 regression models. A generic for LOO-adjusted R-squared is also provided. See
-the \code{bayes_R2.stanreg} method in the \pkg{\link[rstanarm]{rstanarm}} package
-for an example of defining a method.
+the \link[rstanarm:bayes_R2.stanreg]{bayes_R2.stanreg()} method in the
+\pkg{rstanarm} package for an example of defining a method.
 }
 \references{
 Andrew Gelman, Ben Goodrich, Jonah Gabry, and Aki Vehtari (2018). R-squared

--- a/man/bayes_R2.Rd
+++ b/man/bayes_R2.Rd
@@ -18,22 +18,22 @@ loo_R2(object, ...)
 \item{...}{Arguments passed to methods. See the methods in the \pkg{rstanarm}
 package for examples.}
 
-\item{y}{For the default method, a vector of \eqn{y} values the same length
+\item{y}{For the default method, a vector of \code{y} values the same length
 as the number of columns in the matrix used as \code{object}.}
 }
 \value{
-\code{bayes_R2} and \code{loo_R2} methods should return a vector of
+\code{bayes_R2()} and \code{loo_R2()} methods should return a vector of
 length equal to the posterior sample size.
 
-The default \code{bayes_R2} method just takes \code{object} to be a matrix of y-hat values
-(one column per observation, one row per posterior draw) and \code{y} to be
-a vector with length equal to \code{ncol(object)}.
+The default \code{bayes_R2()} method just takes \code{object} to be a matrix of y-hat
+values (one column per observation, one row per posterior draw) and \code{y} to
+be a vector with length equal to \code{ncol(object)}.
 }
 \description{
 Generic function and default method for Bayesian version of R-squared for
 regression models. A generic for LOO-adjusted R-squared is also provided. See
-\code{bayes_R2.stanreg} in the \pkg{\link[rstanarm]{rstanarm}} package for an
-example of defining a method.
+the \code{bayes_R2.stanreg} method in the \pkg{\link[rstanarm]{rstanarm}} package
+for an example of defining a method.
 }
 \references{
 Andrew Gelman, Ben Goodrich, Jonah Gabry, and Aki Vehtari (2018). R-squared
@@ -53,6 +53,6 @@ DOI: 10.1080/00031305.2018.1549100.
 \item Guidelines and recommendations for developers of \R packages
 interfacing with Stan and a demonstration getting a simple package working
 can be found in the vignettes included with \pkg{rstantools} and at
-\url{https://mc-stan.org/rstantools/articles/}.
+\href{https://mc-stan.org/rstantools/articles/}{mc-stan.org/rstantools/articles}.
 }
 }

--- a/man/bayes_R2.Rd
+++ b/man/bayes_R2.Rd
@@ -23,11 +23,11 @@ as the number of columns in the matrix used as \code{object}.}
 }
 \value{
 \code{bayes_R2} and \code{loo_R2} methods should return a vector of
-  length equal to the posterior sample size.
+length equal to the posterior sample size.
 
-  The default \code{bayes_R2} method just takes \code{object} to be a matrix of y-hat values
-  (one column per observation, one row per posterior draw) and \code{y} to be
-  a vector with length equal to \code{ncol(object)}.
+The default \code{bayes_R2} method just takes \code{object} to be a matrix of y-hat values
+(one column per observation, one row per posterior draw) and \code{y} to be
+a vector with length equal to \code{ncol(object)}.
 }
 \description{
 Generic function and default method for Bayesian version of R-squared for
@@ -44,15 +44,15 @@ DOI: 10.1080/00031305.2018.1549100.
 }
 \seealso{
 \itemize{
-  \item The \pkg{\link[rstanarm]{rstanarm}} package for example methods
-  (\href{https://CRAN.R-project.org/package=rstanarm}{CRAN},
-  \href{https://github.com/stan-dev/rstanarm}{GitHub}).
+\item The \pkg{\link[rstanarm]{rstanarm}} package for example methods
+(\href{https://CRAN.R-project.org/package=rstanarm}{CRAN},
+\href{https://github.com/stan-dev/rstanarm}{GitHub}).
 }
 
 \itemize{
-  \item Guidelines and recommendations for developers of \R packages
-  interfacing with Stan and a demonstration getting a simple package working
-  can be found in the vignettes included with \pkg{rstantools} and at
-  \url{https://mc-stan.org/rstantools/articles/}.
+\item Guidelines and recommendations for developers of \R packages
+interfacing with Stan and a demonstration getting a simple package working
+can be found in the vignettes included with \pkg{rstantools} and at
+\url{https://mc-stan.org/rstantools/articles/}.
 }
 }

--- a/man/init_cpp.Rd
+++ b/man/init_cpp.Rd
@@ -15,7 +15,7 @@ directory.}
 }
 \value{
 This function is only called for its side effect of writing the
-  necessary \code{init.cpp} file to the package's \code{src/} directory.
+necessary \code{init.cpp} file to the package's \code{src/} directory.
 }
 \description{
 If you set up your package using \code{rstan_package_skeleton} before

--- a/man/init_cpp.Rd
+++ b/man/init_cpp.Rd
@@ -18,9 +18,9 @@ This function is only called for its side effect of writing the
 necessary \code{init.cpp} file to the package's \code{src/} directory.
 }
 \description{
-If you set up your package using \code{rstan_package_skeleton} before
+If you set up your package using \code{rstan_package_skeleton()} before
 version \code{1.2.1} of \pkg{rstantools} it may be necessary for you to call
-this function yourself in order to pass \code{R CMD check} in \R \code{>=
-3.4}. If you used \code{rstan_package_skeleton} in \pkg{rstantools} version
+this function yourself in order to pass \code{R CMD check} in \R
+\code{>= 3.4}. If you used \code{rstan_package_skeleton()} in \pkg{rstantools} version
 \code{1.2.1} or later then this has already been done automatically.
 }

--- a/man/log_lik.Rd
+++ b/man/log_lik.Rd
@@ -14,8 +14,8 @@ package for examples.}
 }
 \value{
 \code{log_lik} methods should return a \eqn{S} by \eqn{N} matrix,
-  where \eqn{S} is the size of the posterior sample (the number of draws from
-  the posterior distribution) and \eqn{N} is the number of data points.
+where \eqn{S} is the size of the posterior sample (the number of draws from
+the posterior distribution) and \eqn{N} is the number of data points.
 }
 \description{
 We define a new function \code{log_lik} rather than a
@@ -31,15 +31,15 @@ example.
 }
 \seealso{
 \itemize{
-  \item The \pkg{\link[rstanarm]{rstanarm}} package for example methods
-  (\href{https://CRAN.R-project.org/package=rstanarm}{CRAN},
-  \href{https://github.com/stan-dev/rstanarm}{GitHub}).
+\item The \pkg{\link[rstanarm]{rstanarm}} package for example methods
+(\href{https://CRAN.R-project.org/package=rstanarm}{CRAN},
+\href{https://github.com/stan-dev/rstanarm}{GitHub}).
 }
 
 \itemize{
-  \item Guidelines and recommendations for developers of \R packages
-  interfacing with Stan and a demonstration getting a simple package working
-  can be found in the vignettes included with \pkg{rstantools} and at
-  \url{https://mc-stan.org/rstantools/articles/}.
+\item Guidelines and recommendations for developers of \R packages
+interfacing with Stan and a demonstration getting a simple package working
+can be found in the vignettes included with \pkg{rstantools} and at
+\url{https://mc-stan.org/rstantools/articles/}.
 }
 }

--- a/man/log_lik.Rd
+++ b/man/log_lik.Rd
@@ -13,15 +13,15 @@ log_lik(object, ...)
 package for examples.}
 }
 \value{
-\code{log_lik} methods should return a \eqn{S} by \eqn{N} matrix,
+\code{log_lik()} methods should return a \eqn{S} by \eqn{N} matrix,
 where \eqn{S} is the size of the posterior sample (the number of draws from
 the posterior distribution) and \eqn{N} is the number of data points.
 }
 \description{
-We define a new function \code{log_lik} rather than a
+We define a new function \code{log_lik()} rather than a
 \code{\link[stats]{logLik}} method because (in addition to the conceptual
-difference) the documentation for \code{logLik} states that the return value
-will be a single number, whereas \code{log_lik} returns a matrix. See
+difference) the documentation for \code{logLik()} states that the return value
+will be a single number, whereas \code{log_lik()} returns a matrix. See
 \code{\link[rstanarm]{log_lik.stanreg}} in the \pkg{rstanarm} package for an
 example.
 }
@@ -40,6 +40,6 @@ example.
 \item Guidelines and recommendations for developers of \R packages
 interfacing with Stan and a demonstration getting a simple package working
 can be found in the vignettes included with \pkg{rstantools} and at
-\url{https://mc-stan.org/rstantools/articles/}.
+\href{https://mc-stan.org/rstantools/articles/}{mc-stan.org/rstantools/articles}.
 }
 }

--- a/man/log_lik.Rd
+++ b/man/log_lik.Rd
@@ -19,11 +19,11 @@ the posterior distribution) and \eqn{N} is the number of data points.
 }
 \description{
 We define a new function \code{log_lik()} rather than a
-\code{\link[stats]{logLik}} method because (in addition to the conceptual
+\code{\link[stats:logLik]{stats::logLik()}} method because (in addition to the conceptual
 difference) the documentation for \code{logLik()} states that the return value
 will be a single number, whereas \code{log_lik()} returns a matrix. See
-\code{\link[rstanarm]{log_lik.stanreg}} in the \pkg{rstanarm} package for an
-example.
+the \link[rstanarm:log_lik.stanreg]{log_lik.stanreg()} method in the
+\pkg{rstanarm} package for an example of defining a method.
 }
 \examples{
 # See help("log_lik", package = "rstanarm")

--- a/man/loo-prediction.Rd
+++ b/man/loo-prediction.Rd
@@ -35,25 +35,25 @@ of the same length as the number of columns in the matrix used as
 }
 \value{
 \code{loo_predict}, \code{loo_linpred}, and \code{loo_pit}
-  (probability integral transform) methods should return a vector with length
-  equal to the number of observations in the data.
-  \code{loo_predictive_interval} methods should return a two-column matrix
-  formatted in the same way as for \code{\link{predictive_interval}}.
+(probability integral transform) methods should return a vector with length
+equal to the number of observations in the data.
+\code{loo_predictive_interval} methods should return a two-column matrix
+formatted in the same way as for \code{\link{predictive_interval}}.
 }
 \description{
 See the methods in the \pkg{\link[rstanarm]{rstanarm}} package for examples.
 }
 \seealso{
 \itemize{
-  \item The \pkg{\link[rstanarm]{rstanarm}} package for example methods
-  (\href{https://CRAN.R-project.org/package=rstanarm}{CRAN},
-  \href{https://github.com/stan-dev/rstanarm}{GitHub}).
+\item The \pkg{\link[rstanarm]{rstanarm}} package for example methods
+(\href{https://CRAN.R-project.org/package=rstanarm}{CRAN},
+\href{https://github.com/stan-dev/rstanarm}{GitHub}).
 }
 
 \itemize{
-  \item Guidelines and recommendations for developers of \R packages
-  interfacing with Stan and a demonstration getting a simple package working
-  can be found in the vignettes included with \pkg{rstantools} and at
-  \url{https://mc-stan.org/rstantools/articles/}.
+\item Guidelines and recommendations for developers of \R packages
+interfacing with Stan and a demonstration getting a simple package working
+can be found in the vignettes included with \pkg{rstantools} and at
+\url{https://mc-stan.org/rstantools/articles/}.
 }
 }

--- a/man/loo-prediction.Rd
+++ b/man/loo-prediction.Rd
@@ -25,19 +25,17 @@ loo_pit(object, ...)
 \item{...}{Arguments passed to methods. See the methods in the \pkg{rstanarm}
 package for examples.}
 
-\item{y}{For the default method of \code{loo_pit}, a vector of \eqn{y} values
-the same length as the number of columns in the matrix used as
-\code{object}.}
+\item{y}{For the default method of \code{loo_pit()}, a vector of \code{y} values the
+same length as the number of columns in the matrix used as \code{object}.}
 
-\item{lw}{For the default method of \code{loo_pit}, a matrix of log-weights
-of the same length as the number of columns in the matrix used as
-\code{object}.}
+\item{lw}{For the default method of \code{loo_pit()}, a matrix of log-weights of
+the same length as the number of columns in the matrix used as \code{object}.}
 }
 \value{
-\code{loo_predict}, \code{loo_linpred}, and \code{loo_pit}
+\code{loo_predict()}, \code{loo_linpred()}, and \code{loo_pit()}
 (probability integral transform) methods should return a vector with length
 equal to the number of observations in the data.
-\code{loo_predictive_interval} methods should return a two-column matrix
+\code{loo_predictive_interval()} methods should return a two-column matrix
 formatted in the same way as for \code{\link{predictive_interval}}.
 }
 \description{
@@ -54,6 +52,6 @@ See the methods in the \pkg{\link[rstanarm]{rstanarm}} package for examples.
 \item Guidelines and recommendations for developers of \R packages
 interfacing with Stan and a demonstration getting a simple package working
 can be found in the vignettes included with \pkg{rstantools} and at
-\url{https://mc-stan.org/rstantools/articles/}.
+\href{https://mc-stan.org/rstantools/articles/}{mc-stan.org/rstantools/articles}.
 }
 }

--- a/man/loo-prediction.Rd
+++ b/man/loo-prediction.Rd
@@ -36,10 +36,10 @@ the same length as the number of columns in the matrix used as \code{object}.}
 (probability integral transform) methods should return a vector with length
 equal to the number of observations in the data.
 \code{loo_predictive_interval()} methods should return a two-column matrix
-formatted in the same way as for \code{\link{predictive_interval}}.
+formatted in the same way as for \code{\link[=predictive_interval]{predictive_interval()}}.
 }
 \description{
-See the methods in the \pkg{\link[rstanarm]{rstanarm}} package for examples.
+See the methods in the \pkg{rstanarm} package for examples.
 }
 \seealso{
 \itemize{

--- a/man/posterior_interval.Rd
+++ b/man/posterior_interval.Rd
@@ -20,16 +20,16 @@ probability mass to include in the intervals.}
 }
 \value{
 \code{posterior_interval} methods should return a matrix with two
-  columns and as many rows as model parameters (or a subset of parameters
-  specified by the user). For a given value of \code{prob}, \eqn{p}, the
-  columns correspond to the lower and upper \eqn{100p}\% interval limits and
-  have the names \eqn{100\alpha/2}\% and \eqn{100(1 - \alpha/2)}\%, where
-  \eqn{\alpha = 1-p}. For example, if \code{prob=0.9} is specified (a
-  \eqn{90}\% interval), then the column names would be \code{"5\%"} and
-  \code{"95\%"}, respectively.
+columns and as many rows as model parameters (or a subset of parameters
+specified by the user). For a given value of \code{prob}, \eqn{p}, the
+columns correspond to the lower and upper \eqn{100p}\% interval limits and
+have the names \eqn{100\alpha/2}\% and \eqn{100(1 - \alpha/2)}\%, where
+\eqn{\alpha = 1-p}. For example, if \code{prob=0.9} is specified (a
+\eqn{90}\% interval), then the column names would be \code{"5\%"} and
+\code{"95\%"}, respectively.
 
-  The default method just takes \code{object} to be a matrix (one column per
-  parameter) and computes quantiles, with \code{prob} defaulting to 0.9.
+The default method just takes \code{object} to be a matrix (one column per
+parameter) and computes quantiles, with \code{prob} defaulting to 0.9.
 }
 \description{
 These intervals are often referred to as credible intervals, but we use the
@@ -64,15 +64,15 @@ if (require("rstanarm")) {
 }
 \seealso{
 \itemize{
-  \item The \pkg{\link[rstanarm]{rstanarm}} package for example methods
-  (\href{https://CRAN.R-project.org/package=rstanarm}{CRAN},
-  \href{https://github.com/stan-dev/rstanarm}{GitHub}).
+\item The \pkg{\link[rstanarm]{rstanarm}} package for example methods
+(\href{https://CRAN.R-project.org/package=rstanarm}{CRAN},
+\href{https://github.com/stan-dev/rstanarm}{GitHub}).
 }
 
 \itemize{
-  \item Guidelines and recommendations for developers of \R packages
-  interfacing with Stan and a demonstration getting a simple package working
-  can be found in the vignettes included with \pkg{rstantools} and at
-  \url{https://mc-stan.org/rstantools/articles/}.
+\item Guidelines and recommendations for developers of \R packages
+interfacing with Stan and a demonstration getting a simple package working
+can be found in the vignettes included with \pkg{rstantools} and at
+\url{https://mc-stan.org/rstantools/articles/}.
 }
 }

--- a/man/posterior_interval.Rd
+++ b/man/posterior_interval.Rd
@@ -34,9 +34,8 @@ parameter) and computes quantiles, with \code{prob} defaulting to \code{0.9}.
 \description{
 These intervals are often referred to as credible intervals, but we use the
 term uncertainty intervals to highlight the fact that wider intervals
-correspond to greater uncertainty. See
-\code{\link[rstanarm]{posterior_interval.stanreg}} in the
-\pkg{\link[rstanarm]{rstanarm}} package for an example.
+correspond to greater uncertainty. See \code{\link[rstanarm:posterior_interval.stanreg]{rstanarm::posterior_interval.stanreg()}}
+in the \pkg{rstanarm} package for an example.
 }
 \examples{
 # Default method takes a numeric matrix (of posterior draws)

--- a/man/posterior_interval.Rd
+++ b/man/posterior_interval.Rd
@@ -19,7 +19,7 @@ package for examples.}
 probability mass to include in the intervals.}
 }
 \value{
-\code{posterior_interval} methods should return a matrix with two
+\code{posterior_interval()} methods should return a matrix with two
 columns and as many rows as model parameters (or a subset of parameters
 specified by the user). For a given value of \code{prob}, \eqn{p}, the
 columns correspond to the lower and upper \eqn{100p}\% interval limits and
@@ -29,7 +29,7 @@ have the names \eqn{100\alpha/2}\% and \eqn{100(1 - \alpha/2)}\%, where
 \code{"95\%"}, respectively.
 
 The default method just takes \code{object} to be a matrix (one column per
-parameter) and computes quantiles, with \code{prob} defaulting to 0.9.
+parameter) and computes quantiles, with \code{prob} defaulting to \code{0.9}.
 }
 \description{
 These intervals are often referred to as credible intervals, but we use the
@@ -73,6 +73,6 @@ if (require("rstanarm")) {
 \item Guidelines and recommendations for developers of \R packages
 interfacing with Stan and a demonstration getting a simple package working
 can be found in the vignettes included with \pkg{rstantools} and at
-\url{https://mc-stan.org/rstantools/articles/}.
+\href{https://mc-stan.org/rstantools/articles/}{mc-stan.org/rstantools/articles}.
 }
 }

--- a/man/posterior_linpred.Rd
+++ b/man/posterior_linpred.Rd
@@ -24,9 +24,8 @@ distribution distribution and \eqn{N} is the number of data points.
 }
 \description{
 Extract the posterior draws of the linear predictor, possibly transformed by
-the inverse-link function. See
-\code{\link[rstanarm]{posterior_linpred.stanreg}} in the
-\pkg{\link[rstanarm]{rstanarm}} package for an example.
+the inverse-link function. See \code{\link[rstanarm:posterior_linpred.stanreg]{rstanarm::posterior_linpred.stanreg()}} in the
+\pkg{rstanarm} package for an example.
 }
 \examples{
 # See help("posterior_linpred", package = "rstanarm")

--- a/man/posterior_linpred.Rd
+++ b/man/posterior_linpred.Rd
@@ -19,8 +19,8 @@ package for examples.}
 }
 \value{
 \code{posterior_linpred} methods should return a \eqn{D} by \eqn{N}
-  matrix, where \eqn{D} is the number of draws from the posterior
-  distribution distribution and \eqn{N} is the number of data points.
+matrix, where \eqn{D} is the number of draws from the posterior
+distribution distribution and \eqn{N} is the number of data points.
 }
 \description{
 Extract the posterior draws of the linear predictor, possibly transformed by
@@ -34,15 +34,15 @@ the inverse-link function. See
 }
 \seealso{
 \itemize{
-  \item The \pkg{\link[rstanarm]{rstanarm}} package for example methods
-  (\href{https://CRAN.R-project.org/package=rstanarm}{CRAN},
-  \href{https://github.com/stan-dev/rstanarm}{GitHub}).
+\item The \pkg{\link[rstanarm]{rstanarm}} package for example methods
+(\href{https://CRAN.R-project.org/package=rstanarm}{CRAN},
+\href{https://github.com/stan-dev/rstanarm}{GitHub}).
 }
 
 \itemize{
-  \item Guidelines and recommendations for developers of \R packages
-  interfacing with Stan and a demonstration getting a simple package working
-  can be found in the vignettes included with \pkg{rstantools} and at
-  \url{https://mc-stan.org/rstantools/articles/}.
+\item Guidelines and recommendations for developers of \R packages
+interfacing with Stan and a demonstration getting a simple package working
+can be found in the vignettes included with \pkg{rstantools} and at
+\url{https://mc-stan.org/rstantools/articles/}.
 }
 }

--- a/man/posterior_linpred.Rd
+++ b/man/posterior_linpred.Rd
@@ -18,7 +18,7 @@ untransformed linear predictor is returned.}
 package for examples.}
 }
 \value{
-\code{posterior_linpred} methods should return a \eqn{D} by \eqn{N}
+\code{posterior_linpred()} methods should return a \eqn{D} by \eqn{N}
 matrix, where \eqn{D} is the number of draws from the posterior
 distribution distribution and \eqn{N} is the number of data points.
 }
@@ -43,6 +43,6 @@ the inverse-link function. See
 \item Guidelines and recommendations for developers of \R packages
 interfacing with Stan and a demonstration getting a simple package working
 can be found in the vignettes included with \pkg{rstantools} and at
-\url{https://mc-stan.org/rstantools/articles/}.
+\href{https://mc-stan.org/rstantools/articles/}{mc-stan.org/rstantools/articles}.
 }
 }

--- a/man/posterior_predict.Rd
+++ b/man/posterior_predict.Rd
@@ -14,9 +14,9 @@ package for examples.}
 }
 \value{
 \code{posterior_predict} methods should return a \eqn{D} by \eqn{N}
-  matrix, where \eqn{D} is the number of draws from the posterior predictive
-  distribution and \eqn{N} is the number of data points being predicted per
-  draw.
+matrix, where \eqn{D} is the number of draws from the posterior predictive
+distribution and \eqn{N} is the number of data points being predicted per
+draw.
 }
 \description{
 Draw from the posterior predictive distribution of the outcome. See
@@ -43,15 +43,15 @@ if (require("rstanarm")) {
 }
 \seealso{
 \itemize{
-  \item The \pkg{\link[rstanarm]{rstanarm}} package for example methods
-  (\href{https://CRAN.R-project.org/package=rstanarm}{CRAN},
-  \href{https://github.com/stan-dev/rstanarm}{GitHub}).
+\item The \pkg{\link[rstanarm]{rstanarm}} package for example methods
+(\href{https://CRAN.R-project.org/package=rstanarm}{CRAN},
+\href{https://github.com/stan-dev/rstanarm}{GitHub}).
 }
 
 \itemize{
-  \item Guidelines and recommendations for developers of \R packages
-  interfacing with Stan and a demonstration getting a simple package working
-  can be found in the vignettes included with \pkg{rstantools} and at
-  \url{https://mc-stan.org/rstantools/articles/}.
+\item Guidelines and recommendations for developers of \R packages
+interfacing with Stan and a demonstration getting a simple package working
+can be found in the vignettes included with \pkg{rstantools} and at
+\url{https://mc-stan.org/rstantools/articles/}.
 }
 }

--- a/man/posterior_predict.Rd
+++ b/man/posterior_predict.Rd
@@ -13,7 +13,7 @@ posterior_predict(object, ...)
 package for examples.}
 }
 \value{
-\code{posterior_predict} methods should return a \eqn{D} by \eqn{N}
+\code{posterior_predict()} methods should return a \eqn{D} by \eqn{N}
 matrix, where \eqn{D} is the number of draws from the posterior predictive
 distribution and \eqn{N} is the number of data points being predicted per
 draw.
@@ -52,6 +52,6 @@ if (require("rstanarm")) {
 \item Guidelines and recommendations for developers of \R packages
 interfacing with Stan and a demonstration getting a simple package working
 can be found in the vignettes included with \pkg{rstantools} and at
-\url{https://mc-stan.org/rstantools/articles/}.
+\href{https://mc-stan.org/rstantools/articles/}{mc-stan.org/rstantools/articles}.
 }
 }

--- a/man/posterior_predict.Rd
+++ b/man/posterior_predict.Rd
@@ -20,8 +20,8 @@ draw.
 }
 \description{
 Draw from the posterior predictive distribution of the outcome. See
-\code{\link[rstanarm]{posterior_predict.stanreg}} in the
-\pkg{\link[rstanarm]{rstanarm}} package for an example.
+\code{\link[rstanarm:posterior_predict.stanreg]{rstanarm::posterior_predict.stanreg()}} in the \pkg{rstanarm} package for an
+example.
 }
 \examples{
 # Example using rstanarm package:

--- a/man/predictive_error.Rd
+++ b/man/predictive_error.Rd
@@ -15,17 +15,17 @@ predictive_error(object, ...)
 \item{...}{Arguments passed to methods. See the methods in the \pkg{rstanarm}
 package for examples.}
 
-\item{y}{For the default method, a vector of \eqn{y} values the same length
-as the number of columns in the matrix used as \code{object}.}
+\item{y}{For the default method, a vector of \code{y} values the same length as
+the number of columns in the matrix used as \code{object}.}
 }
 \value{
-\code{predictive_error} methods should return a \eqn{D} by \eqn{N}
+\code{predictive_error()} methods should return a \eqn{D} by \eqn{N}
 matrix, where \eqn{D} is the number of draws from the posterior predictive
 distribution and \eqn{N} is the number of data points being predicted per
 draw.
 
-The default method just takes \code{object} to be a matrix and \code{y}
-to be a vector.
+The default method just takes \code{object} to be a matrix and \code{y} to be a
+vector.
 }
 \description{
 Generic function and default method for computing predictive errors
@@ -56,6 +56,6 @@ head(pred_errors)
 \item Guidelines and recommendations for developers of \R packages
 interfacing with Stan and a demonstration getting a simple package working
 can be found in the vignettes included with \pkg{rstantools} and at
-\url{https://mc-stan.org/rstantools/articles/}.
+\href{https://mc-stan.org/rstantools/articles/}{mc-stan.org/rstantools/articles}.
 }
 }

--- a/man/predictive_error.Rd
+++ b/man/predictive_error.Rd
@@ -31,8 +31,8 @@ vector.
 Generic function and default method for computing predictive errors
 \eqn{y - y^{rep}}{y - yrep} (in-sample, for observed \eqn{y}) or
 \eqn{y - \tilde{y}}{y - ytilde} (out-of-sample, for new or held-out \eqn{y}).
-See \code{\link[rstanarm]{predictive_error.stanreg}} in the
-\pkg{\link[rstanarm]{rstanarm}} package for an example.
+See \code{\link[rstanarm:predictive_error.stanreg]{rstanarm::predictive_error.stanreg()}} in the \pkg{rstanarm} package for
+an example.
 }
 \examples{
 # default method

--- a/man/predictive_error.Rd
+++ b/man/predictive_error.Rd
@@ -20,12 +20,12 @@ as the number of columns in the matrix used as \code{object}.}
 }
 \value{
 \code{predictive_error} methods should return a \eqn{D} by \eqn{N}
-  matrix, where \eqn{D} is the number of draws from the posterior predictive
-  distribution and \eqn{N} is the number of data points being predicted per
-  draw.
+matrix, where \eqn{D} is the number of draws from the posterior predictive
+distribution and \eqn{N} is the number of data points being predicted per
+draw.
 
-  The default method just takes \code{object} to be a matrix and \code{y}
-  to be a vector.
+The default method just takes \code{object} to be a matrix and \code{y}
+to be a vector.
 }
 \description{
 Generic function and default method for computing predictive errors
@@ -47,15 +47,15 @@ head(pred_errors)
 }
 \seealso{
 \itemize{
-  \item The \pkg{\link[rstanarm]{rstanarm}} package for example methods
-  (\href{https://CRAN.R-project.org/package=rstanarm}{CRAN},
-  \href{https://github.com/stan-dev/rstanarm}{GitHub}).
+\item The \pkg{\link[rstanarm]{rstanarm}} package for example methods
+(\href{https://CRAN.R-project.org/package=rstanarm}{CRAN},
+\href{https://github.com/stan-dev/rstanarm}{GitHub}).
 }
 
 \itemize{
-  \item Guidelines and recommendations for developers of \R packages
-  interfacing with Stan and a demonstration getting a simple package working
-  can be found in the vignettes included with \pkg{rstantools} and at
-  \url{https://mc-stan.org/rstantools/articles/}.
+\item Guidelines and recommendations for developers of \R packages
+interfacing with Stan and a demonstration getting a simple package working
+can be found in the vignettes included with \pkg{rstantools} and at
+\url{https://mc-stan.org/rstantools/articles/}.
 }
 }

--- a/man/predictive_interval.Rd
+++ b/man/predictive_interval.Rd
@@ -20,15 +20,15 @@ probability mass to include in the intervals.}
 }
 \value{
 \code{predictive_interval} methods should return a matrix with two
-  columns and as many rows as data points being predicted. For a given value
-  of \code{prob}, \eqn{p}, the columns correspond to the lower and upper
-  \eqn{100p}\% interval limits and have the names \eqn{100\alpha/2}\% and
-  \eqn{100(1 - \alpha/2)}\%, where \eqn{\alpha = 1-p}. For example, if
-  \code{prob=0.9} is specified (a \eqn{90}\% interval), then the column names
-  would be \code{"5\%"} and \code{"95\%"}, respectively.
+columns and as many rows as data points being predicted. For a given value
+of \code{prob}, \eqn{p}, the columns correspond to the lower and upper
+\eqn{100p}\% interval limits and have the names \eqn{100\alpha/2}\% and
+\eqn{100(1 - \alpha/2)}\%, where \eqn{\alpha = 1-p}. For example, if
+\code{prob=0.9} is specified (a \eqn{90}\% interval), then the column names
+would be \code{"5\%"} and \code{"95\%"}, respectively.
 
-  The default method just takes \code{object} to be a matrix and computes
-  quantiles, with \code{prob} defaulting to 0.9.
+The default method just takes \code{object} to be a matrix and computes
+quantiles, with \code{prob} defaulting to 0.9.
 }
 \description{
 See \code{\link[rstanarm]{predictive_interval.stanreg}} in the
@@ -45,15 +45,15 @@ predictive_interval(ytilde, prob = 0.8)
 }
 \seealso{
 \itemize{
-  \item The \pkg{\link[rstanarm]{rstanarm}} package for example methods
-  (\href{https://CRAN.R-project.org/package=rstanarm}{CRAN},
-  \href{https://github.com/stan-dev/rstanarm}{GitHub}).
+\item The \pkg{\link[rstanarm]{rstanarm}} package for example methods
+(\href{https://CRAN.R-project.org/package=rstanarm}{CRAN},
+\href{https://github.com/stan-dev/rstanarm}{GitHub}).
 }
 
 \itemize{
-  \item Guidelines and recommendations for developers of \R packages
-  interfacing with Stan and a demonstration getting a simple package working
-  can be found in the vignettes included with \pkg{rstantools} and at
-  \url{https://mc-stan.org/rstantools/articles/}.
+\item Guidelines and recommendations for developers of \R packages
+interfacing with Stan and a demonstration getting a simple package working
+can be found in the vignettes included with \pkg{rstantools} and at
+\url{https://mc-stan.org/rstantools/articles/}.
 }
 }

--- a/man/predictive_interval.Rd
+++ b/man/predictive_interval.Rd
@@ -31,8 +31,8 @@ The default method just takes \code{object} to be a matrix and computes
 quantiles, with \code{prob} defaulting to \code{0.9}.
 }
 \description{
-See \code{\link[rstanarm]{predictive_interval.stanreg}} in the
-\pkg{\link[rstanarm]{rstanarm}} package for an example.
+See \code{\link[rstanarm:predictive_interval.stanreg]{rstanarm::predictive_interval.stanreg()}} in the \pkg{rstanarm} package
+for an example.
 }
 \examples{
 # Default method takes a numeric matrix (of draws from posterior

--- a/man/predictive_interval.Rd
+++ b/man/predictive_interval.Rd
@@ -19,7 +19,7 @@ package for examples.}
 probability mass to include in the intervals.}
 }
 \value{
-\code{predictive_interval} methods should return a matrix with two
+\code{predictive_interval()} methods should return a matrix with two
 columns and as many rows as data points being predicted. For a given value
 of \code{prob}, \eqn{p}, the columns correspond to the lower and upper
 \eqn{100p}\% interval limits and have the names \eqn{100\alpha/2}\% and
@@ -28,7 +28,7 @@ of \code{prob}, \eqn{p}, the columns correspond to the lower and upper
 would be \code{"5\%"} and \code{"95\%"}, respectively.
 
 The default method just takes \code{object} to be a matrix and computes
-quantiles, with \code{prob} defaulting to 0.9.
+quantiles, with \code{prob} defaulting to \code{0.9}.
 }
 \description{
 See \code{\link[rstanarm]{predictive_interval.stanreg}} in the
@@ -54,6 +54,6 @@ predictive_interval(ytilde, prob = 0.8)
 \item Guidelines and recommendations for developers of \R packages
 interfacing with Stan and a demonstration getting a simple package working
 can be found in the vignettes included with \pkg{rstantools} and at
-\url{https://mc-stan.org/rstantools/articles/}.
+\href{https://mc-stan.org/rstantools/articles/}{mc-stan.org/rstantools/articles}.
 }
 }

--- a/man/prior_summary.Rd
+++ b/man/prior_summary.Rd
@@ -17,11 +17,11 @@ package for examples.}
 }
 \value{
 \code{prior_summary} methods should return an object containing
-  information about the prior distribution(s) used for the given model.
-  The structure of this object will depend on the method.
+information about the prior distribution(s) used for the given model.
+The structure of this object will depend on the method.
 
-  The default method just returns \code{object$prior.info}, which is
-  \code{NULL} if there is no \code{'prior.info'} element.
+The default method just returns \code{object$prior.info}, which is
+\code{NULL} if there is no \code{'prior.info'} element.
 }
 \description{
 See \code{\link[rstanarm]{prior_summary.stanreg}} in the
@@ -33,15 +33,15 @@ See \code{\link[rstanarm]{prior_summary.stanreg}} in the
 }
 \seealso{
 \itemize{
-  \item The \pkg{\link[rstanarm]{rstanarm}} package for example methods
-  (\href{https://CRAN.R-project.org/package=rstanarm}{CRAN},
-  \href{https://github.com/stan-dev/rstanarm}{GitHub}).
+\item The \pkg{\link[rstanarm]{rstanarm}} package for example methods
+(\href{https://CRAN.R-project.org/package=rstanarm}{CRAN},
+\href{https://github.com/stan-dev/rstanarm}{GitHub}).
 }
 
 \itemize{
-  \item Guidelines and recommendations for developers of \R packages
-  interfacing with Stan and a demonstration getting a simple package working
-  can be found in the vignettes included with \pkg{rstantools} and at
-  \url{https://mc-stan.org/rstantools/articles/}.
+\item Guidelines and recommendations for developers of \R packages
+interfacing with Stan and a demonstration getting a simple package working
+can be found in the vignettes included with \pkg{rstantools} and at
+\url{https://mc-stan.org/rstantools/articles/}.
 }
 }

--- a/man/prior_summary.Rd
+++ b/man/prior_summary.Rd
@@ -16,7 +16,7 @@ prior_summary(object, ...)
 package for examples.}
 }
 \value{
-\code{prior_summary} methods should return an object containing
+\code{prior_summary()} methods should return an object containing
 information about the prior distribution(s) used for the given model.
 The structure of this object will depend on the method.
 
@@ -42,6 +42,6 @@ See \code{\link[rstanarm]{prior_summary.stanreg}} in the
 \item Guidelines and recommendations for developers of \R packages
 interfacing with Stan and a demonstration getting a simple package working
 can be found in the vignettes included with \pkg{rstantools} and at
-\url{https://mc-stan.org/rstantools/articles/}.
+\href{https://mc-stan.org/rstantools/articles/}{mc-stan.org/rstantools/articles}.
 }
 }

--- a/man/prior_summary.Rd
+++ b/man/prior_summary.Rd
@@ -24,8 +24,8 @@ The default method just returns \code{object$prior.info}, which is
 \code{NULL} if there is no \code{'prior.info'} element.
 }
 \description{
-See \code{\link[rstanarm]{prior_summary.stanreg}} in the
-\pkg{\link[rstanarm]{rstanarm}} package for an example.
+See \code{\link[rstanarm:prior_summary.stanreg]{rstanarm::prior_summary.stanreg()}} in the \pkg{rstanarm} package for an
+example.
 }
 \examples{
 # See help("prior_summary", package = "rstanarm")

--- a/man/rstan_config.Rd
+++ b/man/rstan_config.Rd
@@ -11,7 +11,7 @@ rstan_config(pkgdir = ".")
 }
 \value{
 Invisibly, whether or not any files were added/removed/modified by
-  the function.
+the function.
 }
 \description{
 Creates or update package-specific system files to compile \code{.stan} model
@@ -20,12 +20,12 @@ files found in \code{inst/stan}.
 \details{
 The Stan source files for the package should be stored in:
 \itemize{
-  \item \code{inst/stan} for \code{.stan} files containing instructions to
-  build a \code{stanmodel} object.
-  \item \code{inst/stan/any_subfolder} for files to be included via the
-  \code{#include "/my_subfolder/mylib.stan"} directive.
-  \item \code{inst/stan/any_subfolder} for a \code{license.stan} file.
-  \item \code{inst/include} for the \code{stan_meta_header.hpp} file, to be
-  used for directly interacting with the Stan C++ libraries.
+\item \code{inst/stan} for \code{.stan} files containing instructions to
+build a \code{stanmodel} object.
+\item \code{inst/stan/any_subfolder} for files to be included via the
+\code{#include "/my_subfolder/mylib.stan"} directive.
+\item \code{inst/stan/any_subfolder} for a \code{license.stan} file.
+\item \code{inst/include} for the \code{stan_meta_header.hpp} file, to be
+used for directly interacting with the Stan C++ libraries.
 }
 }

--- a/man/rstan_create_package.Rd
+++ b/man/rstan_create_package.Rd
@@ -13,7 +13,7 @@ rstan_create_package(path, fields = NULL, rstudio = TRUE,
 \item{path}{The path to the new package to be created (terminating in the
 package name).}
 
-\item{fields, rstudio, open}{Same as \code{\link{usethis::create_package}}. See
+\item{fields, rstudio, open}{Same as \code{\link[usethis:create_package]{usethis::create_package()}}. See
 the documentation for that function, especially the note in the
 \strong{Description} section about the side effect of changing the active
 project.}
@@ -83,7 +83,7 @@ Stan C++ library is \code{stan_meta_header.hpp}; all other \code{#include}
 directives must be channeled through here.
 
 The final step of the package creation is to invoke
-\code{\link{rstan_config}}, which creates the following files for
+\code{\link[=rstan_config]{rstan_config()}}, which creates the following files for
 interfacing with Stan objects from \R:
 \itemize{
 \item \code{src} contains the \code{stan_ModelName{.cc/.hpp}} pairs
@@ -136,11 +136,11 @@ program \code{"foo.stan"} you would use \code{rstan::sampling(stanmodels$foo, ..
 
 \seealso{
 \itemize{
-\item \code{\link{use_rstan}} for adding Stan functionality to an existing
-\R package, \code{\link{rstan_config}} for updating an existing package
+\item \code{\link[=use_rstan]{use_rstan()}} for adding Stan functionality to an existing
+\R package and \code{\link[=rstan_config]{rstan_config()}} for updating an existing package
 when its Stan files are changed.
-\item \href{https://github.com/stan-dev/rstanarm}{The \pkg{rstanarm}
-repository on GitHub.}
+\item The \pkg{rstanarm} package \href{https://github.com/stan-dev/rstanarm}{repository}
+on GitHub.
 }
 
 \itemize{

--- a/man/rstan_create_package.Rd
+++ b/man/rstan_create_package.Rd
@@ -43,7 +43,7 @@ whenever the package gets installed (see \strong{Details}). Defaults to \code{TR
 \if{html}{\figure{stanlogo.png}{options: width="25px" alt="https://mc-stan.org/about/logo/"}}
 The \code{rstan_create_package()} function helps get you started developing a
 new \R package that interfaces with Stan via the \pkg{rstan} package. First
-the basic package structure is set up via \code{usethis::create_package()}.
+the basic package structure is set up via \code{\link[usethis:create_package]{usethis::create_package()}}.
 Then several adjustments are made so the package can include Stan programs
 that can be built into binary versions (i.e., pre-compiled Stan C++ code).
 

--- a/man/rstan_create_package.Rd
+++ b/man/rstan_create_package.Rd
@@ -18,18 +18,17 @@ the documentation for that function, especially the note in the
 \strong{Description} section about the side effect of changing the active
 project.}
 
-\item{stan_files}{A character vector with paths to \code{.stan} files to
-include in the package.}
+\item{stan_files}{A character vector with paths to \code{.stan} files to include
+in the package.}
 
 \item{roxygen}{Should \pkg{roxygen2} be used for documentation?  Defaults to
-\code{TRUE}. If so, a file \code{R/{pkgname}-package.R} is added to the
-package with roxygen tags for the required import lines. See the
-\strong{Note} section below for advice specific to the latest versions of
-\pkg{roxygen2}.}
+\code{TRUE}. If so, a file `R/{pkgname}-package.R`` is added to the package with
+roxygen tags for the required import lines. See the \strong{Note} section below
+for advice specific to the latest versions of \pkg{roxygen2}.}
 
-\item{travis}{Should a \code{.travis.yml} file be added to the package
-directory? Defaults to \code{TRUE}.  While the file contains some presets
-to help with compilation issues, at present it is not guaranteed to work on
+\item{travis}{Should a \code{.travis.yml} file be added to the package directory?
+Defaults to \code{TRUE}.  While the file contains some presets to help with
+compilation issues, at present it is not guaranteed to work on
 \href{https://travis-ci.org/}{travis-ci} without manual adjustments.}
 
 \item{license}{Logical or character; whether or not to paste the contents of
@@ -38,14 +37,13 @@ file.  If \code{TRUE} (the default) adds the \code{GPL (>= 3)} license (see
 \strong{Details}).}
 
 \item{auto_config}{Whether to automatically configure Stan functionality
-whenever the package gets installed (see \strong{Details}). Defaults to
-\code{TRUE}.}
+whenever the package gets installed (see \strong{Details}). Defaults to \code{TRUE}.}
 }
 \description{
 \if{html}{\figure{stanlogo.png}{options: width="25px" alt="https://mc-stan.org/about/logo/"}}
-The \code{rstan_create_package} function helps get you started developing a
+The \code{rstan_create_package()} function helps get you started developing a
 new \R package that interfaces with Stan via the \pkg{rstan} package. First
-the basic package structure is set up via \code{usethis::create_package}.
+the basic package structure is set up via \code{usethis::create_package()}.
 Then several adjustments are made so the package can include Stan programs
 that can be built into binary versions (i.e., pre-compiled Stan C++ code).
 
@@ -54,14 +52,14 @@ The \strong{Details} section below describes the process and the
 and a step-by-step walk-through.
 
 As of version \code{2.0.0} of \pkg{rstantools} the
-\code{rstan_package_skeleton} function is defunct and only
-\code{rstan_create_package} is supported.
+\code{rstan_package_skeleton()} function is defunct and only
+\code{rstan_create_package()} is supported.
 }
 \details{
 This function first creates a regular \R package using
-\code{usethis::create_package}, then adds the infrastructure required to
-compile and export \code{stanmodel} objects. In the package root directory,
-the user's Stan source code is located in:
+\code{usethis::create_package()}, then adds the infrastructure required to compile
+and export \code{stanmodel} objects. In the package root directory, the user's
+Stan source code is located in:
 \preformatted{
 inst/
   |_stan/
@@ -99,14 +97,13 @@ Boost (\code{BH}) libraries.
 corresponding to the names of the Stan files).
 }
 
-When \code{auto_config = TRUE}, a \code{configure[.win]} file is
-added to the package, calling \code{rstantools::\link{rstan_config}}
-whenever the package is installed.  Consequently, the package must list
-\code{rstantools} in the \code{DESCRIPTION} Imports field for this
-mechanism to work.  Setting \code{auto_config = FALSE} removes the
-package's dependency on \code{rstantools}.  However, the package then must
-be manually configured by running \code{\link{rstan_config}} whenever
-\code{stanmodel} files in \code{inst/stan} are added/removed/modified.
+When \code{auto_config = TRUE}, a \code{configure[.win]} file is added to the
+package, calling \code{\link[=rstan_config]{rstan_config()}} whenever the package is installed.
+Consequently, the package must list \pkg{rstantools} in the \code{DESCRIPTION}
+Imports field for this mechanism to work.  Setting \code{auto_config = FALSE}
+removes the package's dependency on \pkg{rstantools}, but the package then
+must be manually configured by running \code{\link[=rstan_config]{rstan_config()}} whenever
+\code{stanmodel} files in \code{inst/stan} are added, removed, or modified.
 
 In order to enable Stan functionality, \pkg{\link{rstantools}}
 copies some files to your package.  Since these files are licensed as GPL
@@ -128,14 +125,13 @@ For \pkg{devtools} users, because of changes in the latest versions of
 once before \code{devtools::document()} will work.
 }
 \section{Using the pre-compiled Stan programs in your package}{
-
-The \code{stanmodel} objects corresponding to the Stan programs
-included with your package are stored in a list called \code{stanmodels}.
-To run one of the Stan programs from within an R function in your package
-just pass the appropriate element of the \code{stanmodels} list to one of
-the \pkg{rstan} functions for model fitting (e.g., \code{sampling}). For
-example, for a Stan program "foo.stan" you would use
-\code{rstan::sampling(stanmodels$foo, ...)}.
+ The
+\code{stanmodel} objects corresponding to the Stan programs included with your
+package are stored in a list called \code{stanmodels}. To run one of the Stan
+programs from within an R function in your package just pass the
+appropriate element of the \code{stanmodels} list to one of the \pkg{rstan}
+functions for model fitting (e.g., \code{sampling()}). For example, for a Stan
+program \code{"foo.stan"} you would use \code{rstan::sampling(stanmodels$foo, ...)}.
 }
 
 \seealso{
@@ -151,20 +147,17 @@ repository on GitHub.}
 \item Guidelines and recommendations for developers of \R packages
 interfacing with Stan and a demonstration getting a simple package working
 can be found in the vignettes included with \pkg{rstantools} and at
-\url{https://mc-stan.org/rstantools/articles/}.
+\href{https://mc-stan.org/rstantools/articles/}{mc-stan.org/rstantools/articles}.
 }
 
 \itemize{
-\item After reading the guidelines for developers, if you have trouble
-setting up your package let us know on the the
-\href{https://discourse.mc-stan.org}{Stan Forums} or at
-\href{https://github.com/stan-dev/rstantools/issues}{\pkg{rstantools} issue
-tracker}.
+\item After reading the guidelines for developers, if you have trouble setting up
+your package let us know on the the \href{https://discourse.mc-stan.org}{Stan Forums}
+or at the \pkg{rstantools} GitHub \href{https://github.com/stan-dev/rstantools/issues}{issue tracker}.
 }
 
 \itemize{
 \item The useR2016 presentation
-\href{https://channel9.msdn.com/Events/useR-international-R-User-conferences/useR-International-R-User-2017-Conference/How-to-Use-RStan-to-Estimate-Models-in-External-R-Packages}{How
-to Use (R)Stan to Estimate Models in External R Packages.}
+\href{https://channel9.msdn.com/Events/useR-international-R-User-conferences/useR-International-R-User-2017-Conference/How-to-Use-RStan-to-Estimate-Models-in-External-R-Packages}{How to Use (R)Stan to Estimate Models in External R Packages.}
 }
 }

--- a/man/rstan_create_package.Rd
+++ b/man/rstan_create_package.Rd
@@ -13,14 +13,19 @@ rstan_create_package(path, fields = NULL, rstudio = TRUE,
 \item{path}{The path to the new package to be created (terminating in the
 package name).}
 
-\item{fields, rstudio, open}{Same as for \code{usethis::create_package}.}
+\item{fields, rstudio, open}{Same as \code{\link{usethis::create_package}}. See
+the documentation for that function, especially the note in the
+\strong{Description} section about the side effect of changing the active
+project.}
 
 \item{stan_files}{A character vector with paths to \code{.stan} files to
 include in the package.}
 
 \item{roxygen}{Should \pkg{roxygen2} be used for documentation?  Defaults to
 \code{TRUE}. If so, a file \code{R/{pkgname}-package.R} is added to the
-package with roxygen tags for the required import lines.}
+package with roxygen tags for the required import lines. See the
+\strong{Note} section below for advice specific to the latest versions of
+\pkg{roxygen2}.}
 
 \item{travis}{Should a \code{.travis.yml} file be added to the package
 directory? Defaults to \code{TRUE}.  While the file contains some presets
@@ -44,8 +49,9 @@ whenever the package gets installed (see \strong{Details}). Defaults to
   Then several adjustments are made so the package can include Stan programs
   that can be built into binary versions (i.e., pre-compiled Stan C++ code).
 
-  See the \strong{See Also} section below for links to recommendations for
-  developers and a step-by-step walk-through.
+  The \strong{Details} section below describes the process and the
+  \strong{See Also} section provides links to recommendations for developers
+  and a step-by-step walk-through.
 
   As of version \code{2.0.0} of \pkg{rstantools} the
   \code{rstan_package_skeleton} function is defunct and only
@@ -79,7 +85,7 @@ Stan C++ library is \code{stan_meta_header.hpp}; all other \code{#include}
 directives must be channeled through here.
 
 The final step of the package creation is to invoke
-\code{rstantools::\link{rstan_config}}, which creates the following files for
+\code{\link{rstan_config}}, which creates the following files for
 interfacing with Stan objects from \R:
 \itemize{
   \item \code{src} contains the \code{stan_ModelName{.cc/.hpp}} pairs

--- a/man/rstan_create_package.Rd
+++ b/man/rstan_create_package.Rd
@@ -43,19 +43,19 @@ whenever the package gets installed (see \strong{Details}). Defaults to
 }
 \description{
 \if{html}{\figure{stanlogo.png}{options: width="25px" alt="https://mc-stan.org/about/logo/"}}
-  The \code{rstan_create_package} function helps get you started developing a
-  new \R package that interfaces with Stan via the \pkg{rstan} package. First
-  the basic package structure is set up via \code{usethis::create_package}.
-  Then several adjustments are made so the package can include Stan programs
-  that can be built into binary versions (i.e., pre-compiled Stan C++ code).
+The \code{rstan_create_package} function helps get you started developing a
+new \R package that interfaces with Stan via the \pkg{rstan} package. First
+the basic package structure is set up via \code{usethis::create_package}.
+Then several adjustments are made so the package can include Stan programs
+that can be built into binary versions (i.e., pre-compiled Stan C++ code).
 
-  The \strong{Details} section below describes the process and the
-  \strong{See Also} section provides links to recommendations for developers
-  and a step-by-step walk-through.
+The \strong{Details} section below describes the process and the
+\strong{See Also} section provides links to recommendations for developers
+and a step-by-step walk-through.
 
-  As of version \code{2.0.0} of \pkg{rstantools} the
-  \code{rstan_package_skeleton} function is defunct and only
-  \code{rstan_create_package} is supported.
+As of version \code{2.0.0} of \pkg{rstantools} the
+\code{rstan_package_skeleton} function is defunct and only
+\code{rstan_create_package} is supported.
 }
 \details{
 This function first creates a regular \R package using
@@ -88,82 +88,83 @@ The final step of the package creation is to invoke
 \code{\link{rstan_config}}, which creates the following files for
 interfacing with Stan objects from \R:
 \itemize{
-  \item \code{src} contains the \code{stan_ModelName{.cc/.hpp}} pairs
-  associated with all \code{ModelName.stan} files in \code{inst/stan} which
-  define \code{stanmodel} objects.
-  \item \code{src/Makevars[.win]} which link to the \code{StanHeaders} and
-  Boost (\code{BH}) libraries.
-  \item \code{R/stanmodels.R} loads the C++ modules containing the
-  \code{stanmodel} class definitions, and assigns an \R instance of each
-  \code{stanmodel} object to a \code{stanmodels} list (with names
-  corresponding to the names of the Stan files).
+\item \code{src} contains the \code{stan_ModelName{.cc/.hpp}} pairs
+associated with all \code{ModelName.stan} files in \code{inst/stan} which
+define \code{stanmodel} objects.
+\item \code{src/Makevars[.win]} which link to the \code{StanHeaders} and
+Boost (\code{BH}) libraries.
+\item \code{R/stanmodels.R} loads the C++ modules containing the
+\code{stanmodel} class definitions, and assigns an \R instance of each
+\code{stanmodel} object to a \code{stanmodels} list (with names
+corresponding to the names of the Stan files).
 }
 
 When \code{auto_config = TRUE}, a \code{configure[.win]} file is
-  added to the package, calling \code{rstantools::\link{rstan_config}}
-  whenever the package is installed.  Consequently, the package must list
-  \code{rstantools} in the \code{DESCRIPTION} Imports field for this
-  mechanism to work.  Setting \code{auto_config = FALSE} removes the
-  package's dependency on \code{rstantools}.  However, the package then must
-  be manually configured by running \code{\link{rstan_config}} whenever
-  \code{stanmodel} files in \code{inst/stan} are added/removed/modified.
+added to the package, calling \code{rstantools::\link{rstan_config}}
+whenever the package is installed.  Consequently, the package must list
+\code{rstantools} in the \code{DESCRIPTION} Imports field for this
+mechanism to work.  Setting \code{auto_config = FALSE} removes the
+package's dependency on \code{rstantools}.  However, the package then must
+be manually configured by running \code{\link{rstan_config}} whenever
+\code{stanmodel} files in \code{inst/stan} are added/removed/modified.
 
 In order to enable Stan functionality, \pkg{\link{rstantools}}
-  copies some files to your package.  Since these files are licensed as GPL
-  >= 3, the same license applies to your package should you choose to
-  distribute it.  Even if you don't use \pkg{\link{rstantools}} to create
-  your package, it is likely that you will be linking to \pkg{\link{Rcpp}} to
-  export the Stan C++ \code{stanmodel} objects to \R.  Since
-  \pkg{\link{Rcpp}} is released under GPL >= 2, the same license would apply
-  to your package upon distribution.
+copies some files to your package.  Since these files are licensed as GPL
+
+= 3, the same license applies to your package should you choose to
+distribute it.  Even if you don't use \pkg{\link{rstantools}} to create
+your package, it is likely that you will be linking to \pkg{\link{Rcpp}} to
+export the Stan C++ \code{stanmodel} objects to \R.  Since
+\pkg{\link{Rcpp}} is released under GPL >= 2, the same license would apply
+to your package upon distribution.
 
 Authors willing to license their Stan programs of general interest
-  under the GPL are invited to contribute their \code{.stan} files and
-  supporting \R code to the \pkg{rstanarm} package.
+under the GPL are invited to contribute their \code{.stan} files and
+supporting \R code to the \pkg{rstanarm} package.
 }
 \note{
 For \pkg{devtools} users, because of changes in the latest versions of
-  \pkg{roxygen2} it may be necessary to run \code{pkgbuild::compile_dll()}
-  once before \code{devtools::document()} will work.
+\pkg{roxygen2} it may be necessary to run \code{pkgbuild::compile_dll()}
+once before \code{devtools::document()} will work.
 }
 \section{Using the pre-compiled Stan programs in your package}{
 
-  The \code{stanmodel} objects corresponding to the Stan programs
-  included with your package are stored in a list called \code{stanmodels}.
-  To run one of the Stan programs from within an R function in your package
-  just pass the appropriate element of the \code{stanmodels} list to one of
-  the \pkg{rstan} functions for model fitting (e.g., \code{sampling}). For
-  example, for a Stan program "foo.stan" you would use
-  \code{rstan::sampling(stanmodels$foo, ...)}.
+The \code{stanmodel} objects corresponding to the Stan programs
+included with your package are stored in a list called \code{stanmodels}.
+To run one of the Stan programs from within an R function in your package
+just pass the appropriate element of the \code{stanmodels} list to one of
+the \pkg{rstan} functions for model fitting (e.g., \code{sampling}). For
+example, for a Stan program "foo.stan" you would use
+\code{rstan::sampling(stanmodels$foo, ...)}.
 }
 
 \seealso{
 \itemize{
-  \item \code{\link{use_rstan}} for adding Stan functionality to an existing
-  \R package, \code{\link{rstan_config}} for updating an existing package
-  when its Stan files are changed.
-  \item \href{https://github.com/stan-dev/rstanarm}{The \pkg{rstanarm}
-  repository on GitHub.}
+\item \code{\link{use_rstan}} for adding Stan functionality to an existing
+\R package, \code{\link{rstan_config}} for updating an existing package
+when its Stan files are changed.
+\item \href{https://github.com/stan-dev/rstanarm}{The \pkg{rstanarm}
+repository on GitHub.}
 }
 
 \itemize{
-  \item Guidelines and recommendations for developers of \R packages
-  interfacing with Stan and a demonstration getting a simple package working
-  can be found in the vignettes included with \pkg{rstantools} and at
-  \url{https://mc-stan.org/rstantools/articles/}.
+\item Guidelines and recommendations for developers of \R packages
+interfacing with Stan and a demonstration getting a simple package working
+can be found in the vignettes included with \pkg{rstantools} and at
+\url{https://mc-stan.org/rstantools/articles/}.
 }
 
 \itemize{
-  \item After reading the guidelines for developers, if you have trouble
-  setting up your package let us know on the the
-  \href{https://discourse.mc-stan.org}{Stan Forums} or at
-  \href{https://github.com/stan-dev/rstantools/issues}{\pkg{rstantools} issue
-  tracker}.
+\item After reading the guidelines for developers, if you have trouble
+setting up your package let us know on the the
+\href{https://discourse.mc-stan.org}{Stan Forums} or at
+\href{https://github.com/stan-dev/rstantools/issues}{\pkg{rstantools} issue
+tracker}.
 }
 
 \itemize{
-  \item The useR2016 presentation
-  \href{https://channel9.msdn.com/Events/useR-international-R-User-conferences/useR-International-R-User-2017-Conference/How-to-Use-RStan-to-Estimate-Models-in-External-R-Packages}{How
-  to Use (R)Stan to Estimate Models in External R Packages.}
+\item The useR2016 presentation
+\href{https://channel9.msdn.com/Events/useR-international-R-User-conferences/useR-International-R-User-2017-Conference/How-to-Use-RStan-to-Estimate-Models-in-External-R-Packages}{How
+to Use (R)Stan to Estimate Models in External R Packages.}
 }
 }

--- a/man/rstantools-package.Rd
+++ b/man/rstantools-package.Rd
@@ -16,7 +16,7 @@ packages interfacing with Stan (\url{https://mc-stan.org}), including
 functions to set up the required package structure, S3 generic methods to
 unify function naming across Stan-based \R packages, and vignettes with
 guidelines for developers. To get started building a package see
-\code{\link{rstan_create_package}}.
+\code{\link[=rstan_create_package]{rstan_create_package()}}.
 }
 \seealso{
 \itemize{

--- a/man/rstantools-package.Rd
+++ b/man/rstantools-package.Rd
@@ -8,8 +8,7 @@
 \description{
 \if{html}{
   \figure{stanlogo.png}{options: width="50px" alt="mc-stan.org"}
-  *Stan Development Team*
-}
+} \emph{Stan Development Team}
 
 The \pkg{rstantools} package provides various tools for developers of \R
 packages interfacing with Stan (\url{https://mc-stan.org}), including

--- a/man/rstantools-package.Rd
+++ b/man/rstantools-package.Rd
@@ -8,7 +8,7 @@
 \description{
 \if{html}{
   \figure{stanlogo.png}{options: width="50px" alt="mc-stan.org"}
-  \emph{Stan Development Team}
+  *Stan Development Team*
 }
 
 The \pkg{rstantools} package provides various tools for developers of \R
@@ -23,20 +23,17 @@ guidelines for developers. To get started building a package see
 \item Guidelines and recommendations for developers of \R packages
 interfacing with Stan and a demonstration getting a simple package working
 can be found in the vignettes included with \pkg{rstantools} and at
-\url{https://mc-stan.org/rstantools/articles/}.
+\href{https://mc-stan.org/rstantools/articles/}{mc-stan.org/rstantools/articles}.
 }
 
 \itemize{
-\item After reading the guidelines for developers, if you have trouble
-setting up your package let us know on the the
-\href{https://discourse.mc-stan.org}{Stan Forums} or at
-\href{https://github.com/stan-dev/rstantools/issues}{\pkg{rstantools} issue
-tracker}.
+\item After reading the guidelines for developers, if you have trouble setting up
+your package let us know on the the \href{https://discourse.mc-stan.org}{Stan Forums}
+or at the \pkg{rstantools} GitHub \href{https://github.com/stan-dev/rstantools/issues}{issue tracker}.
 }
 
 \itemize{
 \item The useR2016 presentation
-\href{https://channel9.msdn.com/Events/useR-international-R-User-conferences/useR-International-R-User-2017-Conference/How-to-Use-RStan-to-Estimate-Models-in-External-R-Packages}{How
-to Use (R)Stan to Estimate Models in External R Packages.}
+\href{https://channel9.msdn.com/Events/useR-international-R-User-conferences/useR-International-R-User-2017-Conference/How-to-Use-RStan-to-Estimate-Models-in-External-R-Packages}{How to Use (R)Stan to Estimate Models in External R Packages.}
 }
 }

--- a/man/rstantools-package.Rd
+++ b/man/rstantools-package.Rd
@@ -20,23 +20,23 @@ guidelines for developers. To get started building a package see
 }
 \seealso{
 \itemize{
-  \item Guidelines and recommendations for developers of \R packages
-  interfacing with Stan and a demonstration getting a simple package working
-  can be found in the vignettes included with \pkg{rstantools} and at
-  \url{https://mc-stan.org/rstantools/articles/}.
+\item Guidelines and recommendations for developers of \R packages
+interfacing with Stan and a demonstration getting a simple package working
+can be found in the vignettes included with \pkg{rstantools} and at
+\url{https://mc-stan.org/rstantools/articles/}.
 }
 
 \itemize{
-  \item After reading the guidelines for developers, if you have trouble
-  setting up your package let us know on the the
-  \href{https://discourse.mc-stan.org}{Stan Forums} or at
-  \href{https://github.com/stan-dev/rstantools/issues}{\pkg{rstantools} issue
-  tracker}.
+\item After reading the guidelines for developers, if you have trouble
+setting up your package let us know on the the
+\href{https://discourse.mc-stan.org}{Stan Forums} or at
+\href{https://github.com/stan-dev/rstantools/issues}{\pkg{rstantools} issue
+tracker}.
 }
 
 \itemize{
-  \item The useR2016 presentation
-  \href{https://channel9.msdn.com/Events/useR-international-R-User-conferences/useR-International-R-User-2017-Conference/How-to-Use-RStan-to-Estimate-Models-in-External-R-Packages}{How
-  to Use (R)Stan to Estimate Models in External R Packages.}
+\item The useR2016 presentation
+\href{https://channel9.msdn.com/Events/useR-international-R-User-conferences/useR-International-R-User-2017-Conference/How-to-Use-RStan-to-Estimate-Models-in-External-R-Packages}{How
+to Use (R)Stan to Estimate Models in External R Packages.}
 }
 }

--- a/man/use_rstan.Rd
+++ b/man/use_rstan.Rd
@@ -18,12 +18,12 @@ file.  If \code{TRUE} (the default) adds the \code{GPL (>= 3)} license (see
 whenever the package gets installed (see \strong{Details}). Defaults to \code{TRUE}.}
 }
 \value{
-Invisibly, whether or not any files or folders where created or modified.
+Invisibly, \code{TRUE} or \code{FALSE} indicating whether or not any files or
+folders where created or modified.
 }
 \description{
-Add Stan infrastructure to an existing \R package. To create a \emph{new}
-package containing Stan programs use \code{\link{rstan_create_package}}
-instead.
+Add Stan infrastructure to an existing \R package. To create a \emph{new} package
+containing Stan programs use \code{\link[=rstan_create_package]{rstan_create_package()}} instead.
 }
 \details{
 Prepares a package to compile and use Stan code by performing the
@@ -31,21 +31,18 @@ following steps:
 \enumerate{
 \item Create \code{inst/stan} folder where all \code{.stan} files defining
 Stan models should be stored.
-\item Create \code{inst/stan/include} where optional \code{license.stan}
-file is stored.
-\item Create \code{inst/include/stan_meta_header.hpp} to include optional
-header files used by Stan code.
-\item Create \code{src} folder (if it doesn't exist) to contain the Stan
-C++ code.
-\item Create \code{R} folder (if it doesn't exist) to contain wrapper code
-to expose Stan C++ classes to \R.
-\item Update \code{DESCRIPTION} file to contain all needed dependencies to
-compile Stan C++ code.
-\item If \code{NAMESPACE} file is generic (i.e., created by
-\code{\link{rstan_create_package}}), append \code{import(Rcpp, methods)},
-\code{importFrom(rstan, sampling)}, and \code{useDynLib} directives.  If
-\code{NAMESPACE} is not generic, display message telling user what to add
-to \code{NAMESPACE} for themselves.
+\item Create \code{inst/stan/include} where optional \code{license.stan} file is stored.
+\item Create \code{inst/include/stan_meta_header.hpp} to include optional header
+files used by Stan code.
+\item Create \code{src} folder (if it doesn't exist) to contain the Stan C++ code.
+\item Create \code{R} folder (if it doesn't exist) to contain wrapper code to expose
+Stan C++ classes to \R.
+\item Update \code{DESCRIPTION} file to contain all needed dependencies to compile
+Stan C++ code.
+\item If \code{NAMESPACE} file is generic (i.e., created by \code{\link[=rstan_create_package]{rstan_create_package()}}),
+append \code{import(Rcpp, methods)}, \code{importFrom(rstan, sampling)},
+and \code{useDynLib} directives.  If \code{NAMESPACE} is not generic, display message
+telling user what to add to \code{NAMESPACE} for themselves.
 }
 
 When \code{auto_config = TRUE}, a \code{configure[.win]} file is added to the

--- a/man/use_rstan.Rd
+++ b/man/use_rstan.Rd
@@ -15,8 +15,7 @@ file.  If \code{TRUE} (the default) adds the \code{GPL (>= 3)} license (see
 \strong{Details}).}
 
 \item{auto_config}{Whether to automatically configure Stan functionality
-whenever the package gets installed (see \strong{Details}). Defaults to
-\code{TRUE}.}
+whenever the package gets installed (see \strong{Details}). Defaults to \code{TRUE}.}
 }
 \value{
 Invisibly, whether or not any files or folders where created or modified.
@@ -49,23 +48,21 @@ compile Stan C++ code.
 to \code{NAMESPACE} for themselves.
 }
 
-When \code{auto_config = TRUE}, a \code{configure[.win]} file is
-added to the package, calling \code{rstantools::\link{rstan_config}}
-whenever the package is installed.  Consequently, the package must list
-\code{rstantools} in the \code{DESCRIPTION} Imports field for this
-mechanism to work.  Setting \code{auto_config = FALSE} removes the
-package's dependency on \code{rstantools}.  However, the package then must
-be manually configured by running \code{\link{rstan_config}} whenever
-\code{stanmodel} files in \code{inst/stan} are added/removed/modified.
+When \code{auto_config = TRUE}, a \code{configure[.win]} file is added to the
+package, calling \code{\link[=rstan_config]{rstan_config()}} whenever the package is installed.
+Consequently, the package must list \pkg{rstantools} in the \code{DESCRIPTION}
+Imports field for this mechanism to work.  Setting \code{auto_config = FALSE}
+removes the package's dependency on \pkg{rstantools}, but the package then
+must be manually configured by running \code{\link[=rstan_config]{rstan_config()}} whenever
+\code{stanmodel} files in \code{inst/stan} are added, removed, or modified.
 }
 \section{Using the pre-compiled Stan programs in your package}{
-
-The \code{stanmodel} objects corresponding to the Stan programs
-included with your package are stored in a list called \code{stanmodels}.
-To run one of the Stan programs from within an R function in your package
-just pass the appropriate element of the \code{stanmodels} list to one of
-the \pkg{rstan} functions for model fitting (e.g., \code{sampling}). For
-example, for a Stan program "foo.stan" you would use
-\code{rstan::sampling(stanmodels$foo, ...)}.
+ The
+\code{stanmodel} objects corresponding to the Stan programs included with your
+package are stored in a list called \code{stanmodels}. To run one of the Stan
+programs from within an R function in your package just pass the
+appropriate element of the \code{stanmodels} list to one of the \pkg{rstan}
+functions for model fitting (e.g., \code{sampling()}). For example, for a Stan
+program \code{"foo.stan"} you would use \code{rstan::sampling(stanmodels$foo, ...)}.
 }
 

--- a/man/use_rstan.Rd
+++ b/man/use_rstan.Rd
@@ -28,44 +28,44 @@ instead.
 }
 \details{
 Prepares a package to compile and use Stan code by performing the
-  following steps:
+following steps:
 \enumerate{
-  \item Create \code{inst/stan} folder where all \code{.stan} files defining
-  Stan models should be stored.
-  \item Create \code{inst/stan/include} where optional \code{license.stan}
-  file is stored.
-  \item Create \code{inst/include/stan_meta_header.hpp} to include optional
-  header files used by Stan code.
-  \item Create \code{src} folder (if it doesn't exist) to contain the Stan
-  C++ code.
-  \item Create \code{R} folder (if it doesn't exist) to contain wrapper code
-  to expose Stan C++ classes to \R.
-  \item Update \code{DESCRIPTION} file to contain all needed dependencies to
-  compile Stan C++ code.
-  \item If \code{NAMESPACE} file is generic (i.e., created by
-  \code{\link{rstan_create_package}}), append \code{import(Rcpp, methods)},
-  \code{importFrom(rstan, sampling)}, and \code{useDynLib} directives.  If
-  \code{NAMESPACE} is not generic, display message telling user what to add
-  to \code{NAMESPACE} for themselves.
+\item Create \code{inst/stan} folder where all \code{.stan} files defining
+Stan models should be stored.
+\item Create \code{inst/stan/include} where optional \code{license.stan}
+file is stored.
+\item Create \code{inst/include/stan_meta_header.hpp} to include optional
+header files used by Stan code.
+\item Create \code{src} folder (if it doesn't exist) to contain the Stan
+C++ code.
+\item Create \code{R} folder (if it doesn't exist) to contain wrapper code
+to expose Stan C++ classes to \R.
+\item Update \code{DESCRIPTION} file to contain all needed dependencies to
+compile Stan C++ code.
+\item If \code{NAMESPACE} file is generic (i.e., created by
+\code{\link{rstan_create_package}}), append \code{import(Rcpp, methods)},
+\code{importFrom(rstan, sampling)}, and \code{useDynLib} directives.  If
+\code{NAMESPACE} is not generic, display message telling user what to add
+to \code{NAMESPACE} for themselves.
 }
 
 When \code{auto_config = TRUE}, a \code{configure[.win]} file is
-  added to the package, calling \code{rstantools::\link{rstan_config}}
-  whenever the package is installed.  Consequently, the package must list
-  \code{rstantools} in the \code{DESCRIPTION} Imports field for this
-  mechanism to work.  Setting \code{auto_config = FALSE} removes the
-  package's dependency on \code{rstantools}.  However, the package then must
-  be manually configured by running \code{\link{rstan_config}} whenever
-  \code{stanmodel} files in \code{inst/stan} are added/removed/modified.
+added to the package, calling \code{rstantools::\link{rstan_config}}
+whenever the package is installed.  Consequently, the package must list
+\code{rstantools} in the \code{DESCRIPTION} Imports field for this
+mechanism to work.  Setting \code{auto_config = FALSE} removes the
+package's dependency on \code{rstantools}.  However, the package then must
+be manually configured by running \code{\link{rstan_config}} whenever
+\code{stanmodel} files in \code{inst/stan} are added/removed/modified.
 }
 \section{Using the pre-compiled Stan programs in your package}{
 
-  The \code{stanmodel} objects corresponding to the Stan programs
-  included with your package are stored in a list called \code{stanmodels}.
-  To run one of the Stan programs from within an R function in your package
-  just pass the appropriate element of the \code{stanmodels} list to one of
-  the \pkg{rstan} functions for model fitting (e.g., \code{sampling}). For
-  example, for a Stan program "foo.stan" you would use
-  \code{rstan::sampling(stanmodels$foo, ...)}.
+The \code{stanmodel} objects corresponding to the Stan programs
+included with your package are stored in a list called \code{stanmodels}.
+To run one of the Stan programs from within an R function in your package
+just pass the appropriate element of the \code{stanmodels} list to one of
+the \pkg{rstan} functions for model fitting (e.g., \code{sampling}). For
+example, for a Stan program "foo.stan" you would use
+\code{rstan::sampling(stanmodels$foo, ...)}.
 }
 


### PR DESCRIPTION
This PR converts the roxygen documentation in rstantools (not packages rstantools creates) to use markdown syntax, which is now allowed. 