### PR TITLE
Better error message if the directory already exists

### DIFF
--- a/R/rstan_create_package.R
+++ b/R/rstan_create_package.R
@@ -147,7 +147,7 @@ rstan_create_package <- function(path,
 
   # run usethis::create_package()
   if (file.exists(path)) {
-    stop("Directory '", DIR, "' already exists.", call. = FALSE)
+    stop("Directory '", path, "' already exists.", call. = FALSE)
   }
   message("Creating package skeleton for package: ", name, domain = NA)
   suppressMessages(


### PR DESCRIPTION
This fixes #67 for me.
```
> dir.create("tmp")
> rstan_create_package("tmp")
Error: Directory 'tmp' already exists.
```