### PR TITLE
Change prefix to Rcpp class names to avoid name clashes with rstan

### DIFF
--- a/R/rstan_config.R
+++ b/R/rstan_config.R
@@ -193,7 +193,7 @@ rstan_config <- function(pkgdir = ".") {
   suppressMessages({
     cpp_lines <-
       utils::capture.output(
-               Rcpp::exposeClass(class = paste0("model_", model_name),
+               Rcpp::exposeClass(class = paste0("rstantools_model_", model_name),
                                  constructors = list(c("SEXP", "SEXP", "SEXP")),
                                  fields = character(),
                                  methods = c("call_sampler",

--- a/inst/include/sys/stanmodels.R
+++ b/inst/include/sys/stanmodels.R
@@ -19,5 +19,5 @@ stanmodels <- sapply(stanmodels, function(model_name) {
                model_name = stanfit$model_name,
                model_code = stanfit$model_code,
                model_cpp = stanfit$model_cpp,
-               mk_cppmodule = function(x) get(paste0("model_", model_name)))
+               mk_cppmodule = function(x) get(paste0("rstantools_model_", model_name)))
 })


### PR DESCRIPTION
This seems to do the trick: as I think `rstan` creates uses `model_base` for the new CRTP approach (my guess anyway), I've changed the class name prefix generated by `rstantools` to `rstantools_model_` so that for a file called "base.stan", the Rcpp class won't clash anymore with rstan. 