### PR TITLE
fix r cmd check note about #! interpreter line

### DIFF
--- a/R/rstan_package_utils.R
+++ b/R/rstan_package_utils.R
@@ -72,7 +72,7 @@
   noedit_msg <- .rstantools_noedit(dest_file)
   has_file <- file.exists(dest_file) # check if file exists
   # check if existing file is a stan file
-  is_stanfile <- has_file && (readLines(dest_file, n = 1) == noedit_msg)
+  is_stanfile <- has_file && (noedit_msg %in% readLines(dest_file, n = 5))
   if (has_file && !is_stanfile) {
     # non-stan file found: don't overwrite
     if (warn) .warning_nowrite(file.path(basename(pkgdir), ...))

--- a/R/rstan_package_utils.R
+++ b/R/rstan_package_utils.R
@@ -82,7 +82,7 @@
     if (noedit && (file_lines[1] != noedit_msg)) {
       # add "noedit" to top of file
       if (startsWith(file_lines[1], "#!")) {
-        # in this case no edit msg goes on 2nd line so file starts with #! interpreter line
+        # in this case noedit_msg goes on 2nd line so file starts with #! interpreter line
         # see https://github.com/stan-dev/rstantools/issues/82
         file_lines <- c(file_lines[1], "", noedit_msg, "", file_lines[-1])
       } else {

--- a/R/rstan_package_utils.R
+++ b/R/rstan_package_utils.R
@@ -81,7 +81,13 @@
   if (!has_file || is_stanfile) {
     if (noedit && (file_lines[1] != noedit_msg)) {
       # add "noedit" to top of file
-      file_lines <- c(noedit_msg, "", file_lines)
+      if (startsWith(file_lines[1], "#!")) {
+        # in this case no edit msg goes on 2nd line so file starts with #! interpreter line
+        # see https://github.com/stan-dev/rstantools/issues/82
+        file_lines <- c(file_lines[1], "", noedit_msg, "", file_lines[-1])
+      } else {
+        file_lines <- c(noedit_msg, "", file_lines)
+      }
     }
     if (is_stanfile) {
       # stan file found: check if it needs to be overwritten

--- a/R/use_rstan.R
+++ b/R/use_rstan.R
@@ -228,7 +228,7 @@ use_rstan <- function(pkgdir = ".", license = TRUE, auto_config = TRUE) {
       noedit_msg <- .rstantools_noedit(conf_name)
       conf_name <- file.path(pkgdir, conf_name)
       if (file.exists(conf_name) &&
-         (readLines(conf_name, n = 1) == noedit_msg)) {
+         (noedit_msg %in% readLines(conf_name, n = 5))) {
         file.remove(conf_name) # Stan file found.  remove it
       } else FALSE # no stan file found
     })


### PR DESCRIPTION
Fixes #82. 

Checks if first line is #! interpreter line and if so puts the "don't edit by hand" message on the second line instead of the first. This avoids the new r cmd check note reported in #82. 

