### PR TITLE
Fix RStan 2.26 building & Standalone functions

### DIFF
--- a/R/rstan_config.R
+++ b/R/rstan_config.R
@@ -330,41 +330,41 @@ rstan_config <- function(pkgdir = ".") {
 # Replace auto return type in function exports with the plain type from the main body.
 .replace_auto <- function(decl_line, cppcode, cpp_lines) {
   # Extract the name of function
-  decl = cpp_lines[decl_line]
-  decl = gsub("auto ","",decl,fixed=T)
-  decl = sub("\\(.*","",decl,perl=T)
+  decl <- cpp_lines[decl_line]
+  decl <- gsub("auto ","",decl,fixed=T)
+  decl <- sub("\\(.*","",decl,perl=T)
 
   # Replace newlines with blank spaces
-  t3 = gsub("\n"," ",cppcode,fixed=T)
+  t3 <- gsub("\n"," ",cppcode,fixed=T)
 
   # Identify code segment containing first declaration of function
-  sf1 = strsplit(t3,decl,fixed=T)[[1]][1]
-  sf2 = tail(strsplit(sf1,"template",fixed=T)[[1]],1)
+  sf1 <- strsplit(t3,decl,fixed=T)[[1]][1]
+  sf2 <- tail(strsplit(sf1,";",fixed=T)[[1]],1)
 
   # Get location of type promotion (if present)
-  promote_start = regexec("stan::promote_args_t<",sf2)[[1]]
+  promote_start <- regexec("stan::promote_args_t<",sf2)[[1]]
   
   if(promote_start > 0) {
 
-    str_t = strsplit(sf2,"")[[1]]
-    promote_end = promote_start + attr(promote_start,'match.length')
+    str_t <- strsplit(sf2,"")[[1]]
+    promote_end <- promote_start + attr(promote_start,'match.length')
   
-    count = 1
+    count <- 1
 
     while(count > 0 & promote_end < length(str_t)) {
-      count = count + ifelse(str_t[promote_end] == "<", 1, 
+      count <- count + ifelse(str_t[promote_end] == "<", 1, 
                              ifelse(str_t[promote_end] == ">", -1,0))
-      promote_end = promote_end + 1
+      promote_end <- promote_end + 1
     }
 
-    sf2 = paste0(c(str_t[1:(promote_start-1)], "double",
+    sf2 <- paste0(c(str_t[1:(promote_start-1)], "double",
                    str_t[promote_end:length(str_t)]),
                  collapse = "")
   }
 
   # Extract return type declaration and replace promoted scalar
   #  type with double
-  rtn_type = strsplit(sf2,"<typename(.*?)> ")[[1]][2]
+  rtn_type <- gsub("template <typename(.*?)> ","",sf2)
 
   # Update model code with type declarations
   gsub("auto ", rtn_type, cpp_lines[decl_line],fixed=T)

--- a/R/rstan_config.R
+++ b/R/rstan_config.R
@@ -165,64 +165,87 @@ rstan_config <- function(pkgdir = ".") {
 # the .hpp file contains the C++ level class definition of the given stanmodel
 # the .cc file contains the module definition which Rcpp uses to construct
 # the corresponding R ReferenceClass.
+# If the .stan file has a functions block but no parameters block, then there
+# is no module definition but the functions are compiled and exported to the
+# package's namespace.
 .make_cc <- function(file_name, pkgdir) {
   model_name <- sub("[.]stan$", "", basename(file_name)) # model name
   ## path to src/stan_files
   ## stan_path <- file.path(pkgdir, "src", "stan_files")
   # create c++ code
-  cppcode <- rstan::stanc(file_name, allow_undefined = TRUE,
-                          obfuscate_model_name = FALSE)$cppcode
-  cppcode <- scan(text = cppcode, what = character(), sep = "\n", quiet = TRUE)
-  class_declaration <- grep("^class[[:space:]]+[A-Za-z_]", cppcode)
-  cppcode <- append(cppcode, values = "#include <stan_meta_header.hpp>",
-                    after = class_declaration - 1L)
-  # get license file (if any)
-  stan_license <- .read_license(dirname(file_name))
-  # Stan header file
-  hdr_name <- .stan_prefix(model_name, ".h")
-  .add_stanfile(file_lines = c(stan_license,
-                               "#ifndef MODELS_HPP",
-                               "#define MODELS_HPP",
-                               "#define STAN__SERVICES__COMMAND_HPP",
-                               "#include <rstan/rstaninc.hpp>",
-                               cppcode, "#endif"),
-                pkgdir = pkgdir,
-                "src", hdr_name,
-                noedit = TRUE, msg = FALSE, warn = TRUE)
-  # create Rcpp module exposing C++ class as R ReferenceClass
-  suppressMessages({
-    cpp_lines <-
-      utils::capture.output(
-               Rcpp::exposeClass(class = paste0("rstantools_model_", model_name),
-                                 constructors = list(c("SEXP", "SEXP", "SEXP")),
-                                 fields = character(),
-                                 methods = c("call_sampler",
-                                             "param_names",
-                                             "param_names_oi",
-                                             "param_fnames_oi",
-                                             "param_dims",
-                                             "param_dims_oi",
-                                             "update_param_oi",
-                                             "param_oi_tidx",
-                                             "grad_log_prob",
-                                             "log_prob",
-                                             "unconstrain_pars",
-                                             "constrain_pars",
-                                             "num_pars_unconstrained",
-                                             "unconstrained_param_names",
-                                             "constrained_param_names",
-                                             "standalone_gqs"),
-                                 file = stdout(),
-                                 header = paste0('#include "', hdr_name, '"'),
-                                 module = paste0("stan_fit4",
-                                                 model_name, "_mod"),
-                                 CppClass = "rstan::stan_fit<stan_model, boost::random::ecuyer1988> ",
-                                 Rfile = FALSE)
-             )
-  })
+  stanc_ret <- rstan::stanc(file_name, allow_undefined = TRUE,
+                            obfuscate_model_name = FALSE)
+  only_functions <- grepl("functions[[:space:]]*\\{",  stanc_ret$model_code) &&
+                   !grepl("parameters[[:space:]]*\\{", stanc_ret$model_code)
+  if (only_functions) {
+    # file_name is a collection of Stan functions rather than a model
+    cppcode <- rstan::expose_stan_functions(stanc_ret, dryRun = TRUE)
+    cpp_lines <- scan(text = cppcode, what = character(),
+                      sep = "\n", quiet = TRUE)
+    cpp_lines <- cpp_lines[cpp_lines != "#include <exporter.h>"]
+    cat("#include <exporter.h>",
+        "#include <stan/math/prim/mat/fun/Eigen.hpp>",
+        "#include <stan/model/standalone_functions_header.hpp>",
+        file = file.path(pkgdir, "src",
+                         paste(basename(pkgdir), "types.h", sep = "_")),
+        sep = "\n")
+
+  } else { # actual Stan model
+    cppcode <- stanc_ret$cppcode
+    cppcode <- scan(text = cppcode, what = character(), sep = "\n", quiet = TRUE)
+    class_declaration <- grep("^class[[:space:]]+[A-Za-z_]", cppcode)
+    cppcode <- append(cppcode, values = "#include <stan_meta_header.hpp>",
+                      after = class_declaration - 1L)
+    # get license file (if any)
+    stan_license <- .read_license(dirname(file_name))
+    # Stan header file
+    hdr_name <- .stan_prefix(model_name, ".h")
+    .add_stanfile(file_lines = c(stan_license,
+                                "#ifndef MODELS_HPP",
+                                "#define MODELS_HPP",
+                                "#define STAN__SERVICES__COMMAND_HPP",
+                                "#include <rstan/rstaninc.hpp>",
+                                cppcode, "#endif"),
+                  pkgdir = pkgdir,
+                  "src", hdr_name,
+                  noedit = TRUE, msg = FALSE, warn = TRUE)
+    # create Rcpp module exposing C++ class as R ReferenceClass
+    suppressMessages({
+      cpp_lines <-
+        utils::capture.output(
+                Rcpp::exposeClass(class = paste0("rstantools_model_", model_name),
+                                  constructors = list(c("SEXP", "SEXP", "SEXP")),
+                                  fields = character(),
+                                  methods = c("call_sampler",
+                                              "param_names",
+                                              "param_names_oi",
+                                              "param_fnames_oi",
+                                              "param_dims",
+                                              "param_dims_oi",
+                                              "update_param_oi",
+                                              "param_oi_tidx",
+                                              "grad_log_prob",
+                                              "log_prob",
+                                              "unconstrain_pars",
+                                              "constrain_pars",
+                                              "num_pars_unconstrained",
+                                              "unconstrained_param_names",
+                                              "constrained_param_names",
+                                              "standalone_gqs"),
+                                  file = stdout(),
+                                  header = paste0('#include "', hdr_name, '"'),
+                                  module = paste0("stan_fit4",
+                                                  model_name, "_mod"),
+                                  CppClass = "rstan::stan_fit<stan_model, boost::random::ecuyer1988> ",
+                                  Rfile = FALSE)
+              )
+    })
+  }
   .add_stanfile(file_lines = cpp_lines,
                 pkgdir = pkgdir,
-                "src", .stan_prefix(model_name, ".cc"),
+                "src",
+                ifelse(only_functions, paste0(model_name, ".cpp"),
+                       .stan_prefix(model_name, ".cc")),
                 noedit = TRUE, msg = FALSE, warn = TRUE)
   return(invisible(NULL))
 }
@@ -248,6 +271,12 @@ rstan_config <- function(pkgdir = ".") {
 .update_stanmodels <- function(pkgdir) {
   model_names <- list.files(file.path(pkgdir, "inst", "stan"),
                             pattern = "*.stan$")
+  only_functions <- sapply(model_names, FUN = function(nm) {
+      lns <- readLines(file.path(pkgdir, "inst", "stan", nm))
+      return( grepl("functions[[:space:]]*\\{" , lns) &&
+            !grepl("parameters[[:space:]]*\\{", lns) )
+    })
+  model_names <- model_names[!only_functions]
   model_names <- gsub("[.]stan$", "", model_names)
   if (length(model_names) == 0) {
     stanmodels <- .rstantools_noedit("stanmodels.R")

--- a/R/rstan_config.R
+++ b/R/rstan_config.R
@@ -213,6 +213,9 @@ rstan_config <- function(pkgdir = ".") {
     class_declaration <- grep("^class[[:space:]]+[A-Za-z_]", cppcode)
     cppcode <- append(cppcode, values = "#include <stan_meta_header.hpp>",
                       after = class_declaration - 1L)
+    stanc3_declaration <- grep("#define USE_STANC3", cppcode)
+    cppcode <- append(cppcode, values = "#include <rstan/rstaninc.hpp>",
+                      after = stanc3_declaration)
     # get license file (if any)
     stan_license <- .read_license(dirname(file_name))
     # Stan header file
@@ -221,7 +224,6 @@ rstan_config <- function(pkgdir = ".") {
                                 "#ifndef MODELS_HPP",
                                 "#define MODELS_HPP",
                                 "#define STAN__SERVICES__COMMAND_HPP",
-                                "#include <rstan/rstaninc.hpp>",
                                 cppcode, "#endif"),
                   pkgdir = pkgdir,
                   "src", hdr_name,

--- a/R/rstan_config.R
+++ b/R/rstan_config.R
@@ -145,17 +145,13 @@ rstan_config <- function(pkgdir = ".") {
   if (add) {
     acc <- sapply(c("Makevars", "Makevars.win"), function(mkv_name) {
       makevars <- readLines(.system_file(mkv_name))
-      cat(makevars,file=file.path(pkgdir, "src", mkv_name),
-          sep="\n",append=TRUE)
       .add_stanfile(makevars, pkgdir, "src", mkv_name,
                     noedit = TRUE, msg = FALSE, warn = TRUE)
     })
   } else {
     acc <- sapply(c("Makevars", "Makevars.win"), function(mkv_name) {
       noedit_msg <- .rstantools_noedit(mkv_name)
-      makevars <- readLines(.system_file(mkv_name))
       mkv_name <- file.path(pkgdir, "src", mkv_name)
-      cat(makevars,file=mkv_name, sep="\n",append=TRUE)
       if(file.exists(mkv_name) &&
          (readLines(mkv_name, n = 1) == noedit_msg)) {
         file.remove(mkv_name) # Stan file found.  remove it

--- a/R/rstan_config.R
+++ b/R/rstan_config.R
@@ -176,7 +176,11 @@ rstan_config <- function(pkgdir = ".") {
   stanc_ret <- rstan::stanc(file_name, allow_undefined = TRUE,
                             obfuscate_model_name = FALSE)
   only_functions <- grepl("functions[[:space:]]*\\{",  stanc_ret$model_code) &
-                   !grepl("parameters[[:space:]]*\\{", stanc_ret$model_code)
+                    !grepl("data[[:space:]]*\\{", stanc_ret$model_code) &
+                    !grepl("parameters[[:space:]]*\\{", stanc_ret$model_code) &
+                    !grepl("transformed[[:space:]]parameters[[:space:]]*\\{", stanc_ret$model_code) &
+                    !grepl("model[[:space:]]*\\{", stanc_ret$model_code) &
+                    !grepl("generated[[:space:]]quantities[[:space:]]*\\{", stanc_ret$model_code)
   if (only_functions) {
     # file_name is a collection of Stan functions rather than a model
     cppcode <- rstan::expose_stan_functions(stanc_ret, dryRun = TRUE)
@@ -287,7 +291,11 @@ rstan_config <- function(pkgdir = ".") {
   only_functions <- sapply(model_names, FUN = function(nm) {
       lns <- readLines(file.path(pkgdir, "inst", "stan", nm))
       return(any(grepl("functions[[:space:]]*\\{" , lns)) &
-            !any(grepl("parameters[[:space:]]*\\{", lns)) )
+            !any(grepl("data[[:space:]]*\\{", lns)) &
+            !any(grepl("parameters[[:space:]]*\\{", lns)) &
+            !any(grepl("transformed[[:space:]]parameters[[:space:]]*\\{", lns)) &
+            !any(grepl("model[[:space:]]*\\{", lns)) &
+            !any(grepl("generated[[:space:]]quantities[[:space:]]*\\{", lns)) )
     })
   model_names <- model_names[!only_functions]
   model_names <- gsub("[.]stan$", "", model_names)

--- a/R/rstan_config.R
+++ b/R/rstan_config.R
@@ -145,13 +145,17 @@ rstan_config <- function(pkgdir = ".") {
   if (add) {
     acc <- sapply(c("Makevars", "Makevars.win"), function(mkv_name) {
       makevars <- readLines(.system_file(mkv_name))
+      cat(makevars,file=file.path(pkgdir, "src", mkv_name),
+          sep="\n",append=TRUE)
       .add_stanfile(makevars, pkgdir, "src", mkv_name,
                     noedit = TRUE, msg = FALSE, warn = TRUE)
     })
   } else {
     acc <- sapply(c("Makevars", "Makevars.win"), function(mkv_name) {
       noedit_msg <- .rstantools_noedit(mkv_name)
+      makevars <- readLines(.system_file(mkv_name))
       mkv_name <- file.path(pkgdir, "src", mkv_name)
+      cat(makevars,file=mkv_name, sep="\n",append=TRUE)
       if(file.exists(mkv_name) &&
          (readLines(mkv_name, n = 1) == noedit_msg)) {
         file.remove(mkv_name) # Stan file found.  remove it

--- a/inst/include/sys/Makevars
+++ b/inst/include/sys/Makevars
@@ -1,6 +1,7 @@
 STANHEADERS_SRC = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "message()" -e "cat(system.file('include', 'src', package = 'StanHeaders', mustWork = TRUE))" -e "message()" | grep "StanHeaders")
 
-PKG_CPPFLAGS = -I"../inst/include" -I"$(STANHEADERS_SRC)" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DBOOST_MATH_OVERFLOW_ERROR_POLICY=errno_on_error
+STANC_FLAGS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "cat(ifelse(utils::packageVersion('rstan') >= 2.26, '-DUSE_STANC3',''))")
+PKG_CPPFLAGS = -I"../inst/include" -I"$(STANHEADERS_SRC)" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DBOOST_MATH_OVERFLOW_ERROR_POLICY=errno_on_error $(STANC_FLAGS)
 PKG_CXXFLAGS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::CxxFlags()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::CxxFlags()")
 PKG_LIBS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::RcppParallelLibs()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::LdFlags()")
 

--- a/inst/include/sys/Makevars
+++ b/inst/include/sys/Makevars
@@ -1,6 +1,6 @@
 STANHEADERS_SRC = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "message()" -e "cat(system.file('include', 'src', package = 'StanHeaders', mustWork = TRUE))" -e "message()" | grep "StanHeaders")
 
-PKG_CPPFLAGS = -I"../inst/include" -I"$(STANHEADERS_SRC)" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DBOOST_MATH_OVERFLOW_ERROR_POLICY=errno_on_error
+PKG_CPPFLAGS = -I"../inst/include" -I"$(STANHEADERS_SRC)" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DBOOST_MATH_OVERFLOW_ERROR_POLICY=errno_on_error -DUSE_STANC3
 PKG_CXXFLAGS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::CxxFlags()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::CxxFlags()")
 PKG_LIBS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::RcppParallelLibs()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::LdFlags()")
 

--- a/inst/include/sys/Makevars
+++ b/inst/include/sys/Makevars
@@ -1,6 +1,7 @@
 STANHEADERS_SRC = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "message()" -e "cat(system.file('include', 'src', package = 'StanHeaders', mustWork = TRUE))" -e "message()" | grep "StanHeaders")
 
-PKG_CPPFLAGS = -I"../inst/include" -I"$(STANHEADERS_SRC)" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DBOOST_MATH_OVERFLOW_ERROR_POLICY=errno_on_error -DUSE_STANC3
+STANC_FLAGS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "cat(ifelse(utils::packageVersion('rstan') >= 2.26, '-DUSE_STANC3',''))")
+PKG_CPPFLAGS = -I"../inst/include" -I"$(STANHEADERS_SRC)" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DBOOST_MATH_OVERFLOW_ERROR_POLICY=errno_on_error $(STANC_FLAGS)
 PKG_CXXFLAGS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::CxxFlags()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::CxxFlags()")
 PKG_LIBS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::RcppParallelLibs()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::LdFlags()")
 

--- a/inst/include/sys/Makevars
+++ b/inst/include/sys/Makevars
@@ -1,8 +1,8 @@
 STANHEADERS_SRC = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "message()" -e "cat(system.file('include', 'src', package = 'StanHeaders', mustWork = TRUE))" -e "message()" | grep "StanHeaders")
 
 STANC_FLAGS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "cat(ifelse(utils::packageVersion('rstan') >= 2.26, '-DUSE_STANC3',''))")
-PKG_CPPFLAGS += -I"../inst/include" -I"$(STANHEADERS_SRC)" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DBOOST_MATH_OVERFLOW_ERROR_POLICY=errno_on_error $(STANC_FLAGS)
-PKG_CXXFLAGS += $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::CxxFlags()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::CxxFlags()")
-PKG_LIBS += $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::RcppParallelLibs()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::LdFlags()")
+PKG_CPPFLAGS = -I"../inst/include" -I"$(STANHEADERS_SRC)" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DBOOST_MATH_OVERFLOW_ERROR_POLICY=errno_on_error $(STANC_FLAGS)
+PKG_CXXFLAGS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::CxxFlags()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::CxxFlags()")
+PKG_LIBS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::RcppParallelLibs()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::LdFlags()")
 
 CXX_STD = CXX14

--- a/inst/include/sys/Makevars
+++ b/inst/include/sys/Makevars
@@ -1,7 +1,6 @@
 STANHEADERS_SRC = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "message()" -e "cat(system.file('include', 'src', package = 'StanHeaders', mustWork = TRUE))" -e "message()" | grep "StanHeaders")
 
-STANC_FLAGS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "cat(ifelse(utils::packageVersion('rstan') >= 2.26, '-DUSE_STANC3',''))")
-PKG_CPPFLAGS = -I"../inst/include" -I"$(STANHEADERS_SRC)" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DBOOST_MATH_OVERFLOW_ERROR_POLICY=errno_on_error $(STANC_FLAGS)
+PKG_CPPFLAGS = -I"../inst/include" -I"$(STANHEADERS_SRC)" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DBOOST_MATH_OVERFLOW_ERROR_POLICY=errno_on_error
 PKG_CXXFLAGS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::CxxFlags()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::CxxFlags()")
 PKG_LIBS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::RcppParallelLibs()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::LdFlags()")
 

--- a/inst/include/sys/Makevars
+++ b/inst/include/sys/Makevars
@@ -1,8 +1,8 @@
 STANHEADERS_SRC = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "message()" -e "cat(system.file('include', 'src', package = 'StanHeaders', mustWork = TRUE))" -e "message()" | grep "StanHeaders")
 
 STANC_FLAGS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "cat(ifelse(utils::packageVersion('rstan') >= 2.26, '-DUSE_STANC3',''))")
-PKG_CPPFLAGS = -I"../inst/include" -I"$(STANHEADERS_SRC)" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DBOOST_MATH_OVERFLOW_ERROR_POLICY=errno_on_error $(STANC_FLAGS)
-PKG_CXXFLAGS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::CxxFlags()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::CxxFlags()")
-PKG_LIBS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::RcppParallelLibs()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::LdFlags()")
+PKG_CPPFLAGS += -I"../inst/include" -I"$(STANHEADERS_SRC)" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DBOOST_MATH_OVERFLOW_ERROR_POLICY=errno_on_error $(STANC_FLAGS)
+PKG_CXXFLAGS += $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::CxxFlags()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::CxxFlags()")
+PKG_LIBS += $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::RcppParallelLibs()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::LdFlags()")
 
 CXX_STD = CXX14

--- a/inst/include/sys/Makevars.win
+++ b/inst/include/sys/Makevars.win
@@ -1,6 +1,7 @@
 STANHEADERS_SRC = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "message()" -e "cat(system.file('include', 'src', package = 'StanHeaders', mustWork = TRUE))" -e "message()" | grep "StanHeaders")
 
-PKG_CPPFLAGS = -I"../inst/include" -I"$(STANHEADERS_SRC)" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DRCPP_PARALLEL_USE_TBB=1
+STANC_FLAGS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "cat(ifelse(utils::packageVersion('rstan') >= 2.26, '-DUSE_STANC3',''))")
+PKG_CPPFLAGS = -I"../inst/include" -I"$(STANHEADERS_SRC)" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DRCPP_PARALLEL_USE_TBB=1 $(STANC_FLAGS)
 PKG_CXXFLAGS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::CxxFlags()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::CxxFlags()")
 PKG_LIBS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::RcppParallelLibs()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::LdFlags()")
 

--- a/inst/include/sys/Makevars.win
+++ b/inst/include/sys/Makevars.win
@@ -1,6 +1,6 @@
 STANHEADERS_SRC = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "message()" -e "cat(system.file('include', 'src', package = 'StanHeaders', mustWork = TRUE))" -e "message()" | grep "StanHeaders")
 
-PKG_CPPFLAGS = -I"../inst/include" -I"$(STANHEADERS_SRC)" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DRCPP_PARALLEL_USE_TBB=1
+PKG_CPPFLAGS = -I"../inst/include" -I"$(STANHEADERS_SRC)" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DRCPP_PARALLEL_USE_TBB=1 -DUSE_STANC3
 PKG_CXXFLAGS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::CxxFlags()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::CxxFlags()")
 PKG_LIBS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::RcppParallelLibs()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::LdFlags()")
 

--- a/inst/include/sys/Makevars.win
+++ b/inst/include/sys/Makevars.win
@@ -1,8 +1,8 @@
 STANHEADERS_SRC = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "message()" -e "cat(system.file('include', 'src', package = 'StanHeaders', mustWork = TRUE))" -e "message()" | grep "StanHeaders")
 
 STANC_FLAGS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "cat(ifelse(utils::packageVersion('rstan') >= 2.26, '-DUSE_STANC3',''))")
-PKG_CPPFLAGS = -I"../inst/include" -I"$(STANHEADERS_SRC)" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DRCPP_PARALLEL_USE_TBB=1 $(STANC_FLAGS)
-PKG_CXXFLAGS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::CxxFlags()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::CxxFlags()")
-PKG_LIBS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::RcppParallelLibs()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::LdFlags()")
+PKG_CPPFLAGS += -I"../inst/include" -I"$(STANHEADERS_SRC)" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DRCPP_PARALLEL_USE_TBB=1 $(STANC_FLAGS)
+PKG_CXXFLAGS += $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::CxxFlags()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::CxxFlags()")
+PKG_LIBS += $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::RcppParallelLibs()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::LdFlags()")
 
 CXX_STD = CXX14

--- a/inst/include/sys/Makevars.win
+++ b/inst/include/sys/Makevars.win
@@ -1,8 +1,8 @@
 STANHEADERS_SRC = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "message()" -e "cat(system.file('include', 'src', package = 'StanHeaders', mustWork = TRUE))" -e "message()" | grep "StanHeaders")
 
 STANC_FLAGS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "cat(ifelse(utils::packageVersion('rstan') >= 2.26, '-DUSE_STANC3',''))")
-PKG_CPPFLAGS += -I"../inst/include" -I"$(STANHEADERS_SRC)" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DRCPP_PARALLEL_USE_TBB=1 $(STANC_FLAGS)
-PKG_CXXFLAGS += $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::CxxFlags()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::CxxFlags()")
-PKG_LIBS += $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::RcppParallelLibs()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::LdFlags()")
+PKG_CPPFLAGS = -I"../inst/include" -I"$(STANHEADERS_SRC)" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DRCPP_PARALLEL_USE_TBB=1 $(STANC_FLAGS)
+PKG_CXXFLAGS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::CxxFlags()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::CxxFlags()")
+PKG_LIBS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::RcppParallelLibs()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::LdFlags()")
 
 CXX_STD = CXX14

--- a/inst/include/sys/Makevars.win
+++ b/inst/include/sys/Makevars.win
@@ -1,7 +1,6 @@
 STANHEADERS_SRC = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "message()" -e "cat(system.file('include', 'src', package = 'StanHeaders', mustWork = TRUE))" -e "message()" | grep "StanHeaders")
 
-STANC_FLAGS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "cat(ifelse(utils::packageVersion('rstan') >= 2.26, '-DUSE_STANC3',''))")
-PKG_CPPFLAGS = -I"../inst/include" -I"$(STANHEADERS_SRC)" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DRCPP_PARALLEL_USE_TBB=1 $(STANC_FLAGS)
+PKG_CPPFLAGS = -I"../inst/include" -I"$(STANHEADERS_SRC)" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DRCPP_PARALLEL_USE_TBB=1
 PKG_CXXFLAGS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::CxxFlags()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::CxxFlags()")
 PKG_LIBS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::RcppParallelLibs()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::LdFlags()")
 

--- a/inst/include/sys/Makevars.win
+++ b/inst/include/sys/Makevars.win
@@ -1,6 +1,7 @@
 STANHEADERS_SRC = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "message()" -e "cat(system.file('include', 'src', package = 'StanHeaders', mustWork = TRUE))" -e "message()" | grep "StanHeaders")
 
-PKG_CPPFLAGS = -I"../inst/include" -I"$(STANHEADERS_SRC)" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DRCPP_PARALLEL_USE_TBB=1 -DUSE_STANC3
+STANC_FLAGS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "cat(ifelse(utils::packageVersion('rstan') >= 2.26, '-DUSE_STANC3',''))")
+PKG_CPPFLAGS = -I"../inst/include" -I"$(STANHEADERS_SRC)" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DRCPP_PARALLEL_USE_TBB=1 $(STANC_FLAGS)
 PKG_CXXFLAGS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::CxxFlags()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::CxxFlags()")
 PKG_LIBS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::RcppParallelLibs()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::LdFlags()")
 


### PR DESCRIPTION
This PR updates `rstan_config()` to define `USE_STANC3` prior to including stan headers, and also adds functionality for building packages with stan models of just standalone functions