### PR TITLE
Fix additions and add GHA R CMD CHECK

### DIFF
--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -1,0 +1,74 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+name: R-CMD-check
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: macOS-latest,   r: 'release'}
+          - {os: windows-latest, r: 'release'}
+          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,   r: 'release'}
+          - {os: ubuntu-latest,   r: 'oldrel-1'}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-pandoc@v1
+
+      - uses: r-lib/actions/setup-r@v1
+        with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v1
+        with:
+          extra-packages: rcmdcheck BH RcppParallel RcppEigen Rcpp rstan StanHeaders
+
+      - uses: r-lib/actions/check-r-package@v1
+
+      - name: Check against Development StanHeaders and CRAN RStan
+        run: |
+          install.packages("StanHeaders", repos = c("https://mc-stan.org/r-packages/", getOption("repos")))
+          install.packages('rstan', type='source')
+        shell: Rscript {0}
+
+      - uses: r-lib/actions/check-r-package@v1
+
+      - name: Check against Development StanHeaders and Development RStan
+        run: |
+          install.packages("StanHeaders", repos = c("https://mc-stan.org/r-packages/", getOption("repos")))
+          install.packages("rstan", repos = c("https://mc-stan.org/r-packages/", getOption("repos")))
+        shell: Rscript {0}
+
+      - uses: r-lib/actions/check-r-package@v1
+
+      - name: Show testthat output
+        if: always()
+        run: find check -name 'testthat.Rout*' -exec cat '{}' \; || true
+        shell: bash
+
+      - name: Upload check results
+        if: failure()
+        uses: actions/upload-artifact@main
+        with:
+          name: ${{ runner.os }}-r${{ matrix.config.r }}-results
+          path: check

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,6 +44,6 @@ Suggests:
     roxygen2 (>= 6.0.1),
     rmarkdown,
     rstudioapi
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 VignetteBuilder: knitr
 Roxygen: list(markdown = TRUE)

--- a/vignettes/minimal-rstan-package.Rmd
+++ b/vignettes/minimal-rstan-package.Rmd
@@ -247,7 +247,6 @@ roxygen2::roxygenize()
 ```
 ```{r, echo=FALSE}
 try(roxygen2::roxygenize(PATH, load_code = sourceDir), silent = TRUE)
-rm(lm_stan)
 roxygen2::roxygenize(PATH)
 ```
 


### PR DESCRIPTION
@jgabry, the errors were caused by my changes to `rstan_config` not being backwards-compatible to 2.21. I've updated the changes and also added github actions for running R CMD CHECK against the various combinations of CRAN and dev rstan/stanheaders so that this would be caught in the future