### PR TITLE
`rstan_config`: Fix includes

### DIFF
--- a/R/rstan_config.R
+++ b/R/rstan_config.R
@@ -185,7 +185,9 @@ rstan_config <- function(pkgdir = ".") {
   }
   stanc_ret <- rstan::stanc(file_name, allow_undefined = TRUE,
                             obfuscate_model_name = FALSE,
-                            isystem = file.path(pkgdir, "inst", "stan"))
+                            isystem = c(dirname(file_name), getwd(),
+                                        file.path(pkgdir, "inst", "stan"),
+                                        file.path(pkgdir, "inst", "include")))
   only_functions <- grepl("functions[[:space:]]*\\{",  stanc_ret$model_code) &
                     !grepl("data[[:space:]]*\\{", stanc_ret$model_code) &
                     !grepl("parameters[[:space:]]*\\{", stanc_ret$model_code) &


### PR DESCRIPTION
#94 overrides the default `isystem` when calling `rstan::stanc()`, which breaks some packages. This PR appends extra inlcudes to the default `isystem`. Some of them may not be required.