### PR TITLE
Update C++ Standard to C++17

### DIFF
--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -32,20 +32,20 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: rcmdcheck BH RcppParallel RcppEigen Rcpp rstan StanHeaders
 
       - name: Check against CRAN StanHeaders and CRAN RStan
-        uses: r-lib/actions/check-r-package@v1
+        uses: r-lib/actions/check-r-package@v2
 
       - name: Install Development StanHeaders and CRAN RStan
         run: |
@@ -55,7 +55,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Check against Development StanHeaders and CRAN RStan
-        uses: r-lib/actions/check-r-package@v1
+        uses: r-lib/actions/check-r-package@v2
 
       - name: Install Development StanHeaders and Development RStan
         run: |
@@ -65,7 +65,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Check against Development StanHeaders and Development RStan
-        uses: r-lib/actions/check-r-package@v1
+        uses: r-lib/actions/check-r-package@v2
 
       - name: Show testthat output
         if: always()

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Type: Package
 Title: Tools for Developing R Packages Interfacing with 'Stan'
 Version: 2.2.0.9000
 Date: 2022-04-05
-Authors@R: 
+Authors@R:
     c(person(given = "Jonah",
              family = "Gabry",
              role = c("aut", "cre"),
@@ -18,7 +18,7 @@ Authors@R:
              email = "mlysy@uwaterloo.ca"),
       person(given = "Andrew",
              family = "Johnson",
-             role = "ctb"),
+             role = "aut"),
       person(given = "Hamada S.",
              family = "Badr",
              role = "ctb"),
@@ -32,9 +32,9 @@ Authors@R:
              family = "Columbia University",
              role = "cph"))
 Description: Provides various tools for developers of R packages interfacing
-    with 'Stan' <https://mc-stan.org>, including functions to set up the required 
-    package structure, S3 generics and default methods to unify function naming 
-    across 'Stan'-based R packages, and vignettes with recommendations for 
+    with 'Stan' <https://mc-stan.org>, including functions to set up the required
+    package structure, S3 generics and default methods to unify function naming
+    across 'Stan'-based R packages, and vignettes with recommendations for
     developers.
 License: GPL (>=3)
 URL: https://mc-stan.org/rstantools/, https://discourse.mc-stan.org/

--- a/inst/include/sys/Makevars
+++ b/inst/include/sys/Makevars
@@ -1,7 +1,7 @@
 STANHEADERS_SRC = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "message()" -e "cat(system.file('include', 'src', package = 'StanHeaders', mustWork = TRUE))" -e "message()" | grep "StanHeaders")
 
 STANC_FLAGS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "cat(ifelse(utils::packageVersion('rstan') >= 2.26, '-DUSE_STANC3',''))")
-PKG_CPPFLAGS = -I"../inst/include" -I"$(STANHEADERS_SRC)" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DBOOST_MATH_OVERFLOW_ERROR_POLICY=errno_on_error $(STANC_FLAGS)
+PKG_CPPFLAGS = -I"../inst/include" -I"$(STANHEADERS_SRC)" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DBOOST_MATH_OVERFLOW_ERROR_POLICY=errno_on_error $(STANC_FLAGS) -D_HAS_AUTO_PTR_ETC=0
 PKG_CXXFLAGS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::CxxFlags()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::CxxFlags()")
 PKG_LIBS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::RcppParallelLibs()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::LdFlags()")
 

--- a/inst/include/sys/Makevars
+++ b/inst/include/sys/Makevars
@@ -5,4 +5,4 @@ PKG_CPPFLAGS = -I"../inst/include" -I"$(STANHEADERS_SRC)" -DBOOST_DISABLE_ASSERT
 PKG_CXXFLAGS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::CxxFlags()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::CxxFlags()")
 PKG_LIBS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::RcppParallelLibs()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::LdFlags()")
 
-CXX_STD = CXX14
+CXX_STD = CXX17

--- a/inst/include/sys/Makevars.win
+++ b/inst/include/sys/Makevars.win
@@ -5,4 +5,4 @@ PKG_CPPFLAGS = -I"../inst/include" -I"$(STANHEADERS_SRC)" -DBOOST_DISABLE_ASSERT
 PKG_CXXFLAGS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::CxxFlags()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::CxxFlags()")
 PKG_LIBS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::RcppParallelLibs()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::LdFlags()")
 
-CXX_STD = CXX14
+CXX_STD = CXX17

--- a/inst/include/sys/Makevars.win
+++ b/inst/include/sys/Makevars.win
@@ -1,7 +1,7 @@
 STANHEADERS_SRC = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "message()" -e "cat(system.file('include', 'src', package = 'StanHeaders', mustWork = TRUE))" -e "message()" | grep "StanHeaders")
 
 STANC_FLAGS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "cat(ifelse(utils::packageVersion('rstan') >= 2.26, '-DUSE_STANC3',''))")
-PKG_CPPFLAGS = -I"../inst/include" -I"$(STANHEADERS_SRC)" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DRCPP_PARALLEL_USE_TBB=1 $(STANC_FLAGS)
+PKG_CPPFLAGS = -I"../inst/include" -I"$(STANHEADERS_SRC)" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DRCPP_PARALLEL_USE_TBB=1 $(STANC_FLAGS) -D_HAS_AUTO_PTR_ETC=0
 PKG_CXXFLAGS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::CxxFlags()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::CxxFlags()")
 PKG_LIBS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::RcppParallelLibs()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::LdFlags()")
 


### PR DESCRIPTION
As discussed over [on the forums](https://discourse.mc-stan.org/t/cran-note-for-package-using-stan-suggest-c-17/30247), CRAN has begun issuing a `NOTE` when the requested C++ standard is lower than C++17. This PR updates the rstantools-provided Makevars to request the higher standard.

I've run reverse-dependency checks and all packages continue to build and pass. This will break the current `rstan` 2.26, but I've already opened a PR with the needed patches [here](https://github.com/stan-dev/math/pull/2873)