### PR TITLE
Fix compatibility for exporting standalone functions, add tests

### DIFF
--- a/.github/workflows/check-standalone.yaml
+++ b/.github/workflows/check-standalone.yaml
@@ -48,6 +48,7 @@ jobs:
       - name: Check against CRAN StanHeaders and CRAN RStan
         run: |
           rcmdcheck::rcmdcheck(path = "lgpr", args = c("--no-manual", "--as-cran"), build_args = "--no-manual")
+        shell: Rscript {0}
 
       - name: Install Development StanHeaders and CRAN RStan
         run: |
@@ -59,6 +60,7 @@ jobs:
       - name: Check against CRAN StanHeaders and CRAN RStan
         run: |
           rcmdcheck::rcmdcheck(path = "lgpr", args = c("--no-manual", "--as-cran"), build_args = "--no-manual")
+        shell: Rscript {0}
 
       - name: Install Development StanHeaders and Development RStan
         run: |
@@ -70,4 +72,5 @@ jobs:
       - name: Check against CRAN StanHeaders and CRAN RStan
         run: |
           rcmdcheck::rcmdcheck(path = "lgpr", args = c("--no-manual", "--as-cran"), build_args = "--no-manual")
+        shell: Rscript {0}
 

--- a/.github/workflows/check-standalone.yaml
+++ b/.github/workflows/check-standalone.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: local::. rcmdcheck BH RcppParallel RcppEigen Rcpp rstan StanHeaders
+          extra-packages: local::. rcmdcheck BH RcppParallel RcppEigen Rcpp rstan StanHeaders RCurl
 
       - name: Checkout lgpr package
         run: |

--- a/.github/workflows/check-standalone.yaml
+++ b/.github/workflows/check-standalone.yaml
@@ -57,7 +57,7 @@ jobs:
           install.packages('rstan', type='source')
         shell: Rscript {0}
 
-      - name: Check against CRAN StanHeaders and CRAN RStan
+      - name: Check against Development StanHeaders and CRAN RStan
         run: |
           rcmdcheck::rcmdcheck(path = "lgpr", args = c("--no-manual", "--as-cran"), build_args = "--no-manual")
         shell: Rscript {0}
@@ -69,7 +69,7 @@ jobs:
           install.packages("rstan", repos = c("https://mc-stan.org/r-packages/", getOption("repos")))
         shell: Rscript {0}
 
-      - name: Check against CRAN StanHeaders and CRAN RStan
+      - name: Check against Development StanHeaders and Development RStan
         run: |
           rcmdcheck::rcmdcheck(path = "lgpr", args = c("--no-manual", "--as-cran"), build_args = "--no-manual")
         shell: Rscript {0}

--- a/.github/workflows/check-standalone.yaml
+++ b/.github/workflows/check-standalone.yaml
@@ -1,0 +1,73 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+name: Stanfunctions Support
+
+jobs:
+  stanfunctions-support:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,   r: 'release'}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: local::. rcmdcheck BH RcppParallel RcppEigen Rcpp rstan StanHeaders
+
+      - name: Checkout lgpr package
+        run: |
+          git clone https://github.com/andrjohns/lgpr
+          cd lgpr && git checkout function-exports
+
+      - name: Check against CRAN StanHeaders and CRAN RStan
+        run: |
+          rcmdcheck::rcmdcheck(path = "lgpr", args = c("--no-manual", "--as-cran"), build_args = "--no-manual")
+
+      - name: Install Development StanHeaders and CRAN RStan
+        run: |
+          Sys.setenv(MAKEFLAGS=paste0("-j",parallel::detectCores()))
+          install.packages("StanHeaders", repos = c("https://mc-stan.org/r-packages/", getOption("repos")))
+          install.packages('rstan', type='source')
+        shell: Rscript {0}
+
+      - name: Check against CRAN StanHeaders and CRAN RStan
+        run: |
+          rcmdcheck::rcmdcheck(path = "lgpr", args = c("--no-manual", "--as-cran"), build_args = "--no-manual")
+
+      - name: Install Development StanHeaders and Development RStan
+        run: |
+          Sys.setenv(MAKEFLAGS=paste0("-j",parallel::detectCores()))
+          install.packages("StanHeaders", repos = c("https://mc-stan.org/r-packages/", getOption("repos")))
+          install.packages("rstan", repos = c("https://mc-stan.org/r-packages/", getOption("repos")))
+        shell: Rscript {0}
+
+      - name: Check against CRAN StanHeaders and CRAN RStan
+        run: |
+          rcmdcheck::rcmdcheck(path = "lgpr", args = c("--no-manual", "--as-cran"), build_args = "--no-manual")
+

--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -20,7 +20,7 @@ jobs:
         config:
           - {os: macOS-latest,   r: 'release'}
           # Vignette building hangs infinitely on Windows GHA, so disable for now
-          #- {os: windows-latest, r: 'release'}
+          - {os: windows-latest, r: 'release'}
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
           - {os: ubuntu-latest,   r: 'oldrel-1'}
@@ -30,22 +30,22 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: rcmdcheck BH RcppParallel RcppEigen Rcpp rstan StanHeaders
 
       - name: Check against CRAN StanHeaders and CRAN RStan
-        uses: r-lib/actions/check-r-package@v1
+        uses: r-lib/actions/check-r-package@v2
 
       - name: Install Development StanHeaders and CRAN RStan
         run: |
@@ -55,7 +55,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Check against Development StanHeaders and CRAN RStan
-        uses: r-lib/actions/check-r-package@v1
+        uses: r-lib/actions/check-r-package@v2
 
       - name: Install Development StanHeaders and Development RStan
         run: |
@@ -65,7 +65,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Check against Development StanHeaders and Development RStan
-        uses: r-lib/actions/check-r-package@v1
+        uses: r-lib/actions/check-r-package@v2
 
       - name: Show testthat output
         if: always()

--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -20,7 +20,7 @@ jobs:
         config:
           - {os: macOS-latest,   r: 'release'}
           # Vignette building hangs infinitely on Windows GHA, so disable for now
-          - {os: windows-latest, r: 'release'}
+          #- {os: windows-latest, r: 'release'}
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
           - {os: ubuntu-latest,   r: 'oldrel-1'}

--- a/R/rstan_config.R
+++ b/R/rstan_config.R
@@ -180,7 +180,7 @@ rstan_config <- function(pkgdir = ".") {
       (utils::packageVersion('rstan') < 2.29)) {
     mod <- readLines(file_name)
     if (!any(grepl("\\bfunctions(\\s*|)\\{", mod))) {
-      writeLines("functions {", mod, "}", sep = "\n", con = file_name)
+      writeLines(c("functions {", mod, "}"), sep = "\n", con = file_name)
     }
   }
   stanc_ret <- rstan::stanc(file_name, allow_undefined = TRUE,

--- a/R/rstan_config.R
+++ b/R/rstan_config.R
@@ -179,8 +179,8 @@ rstan_config <- function(pkgdir = ".") {
   if (grepl("\\.stanfunctions$", file_name) &&
       (utils::packageVersion('rstan') < 2.29)) {
     mod <- readLines(file_name)
-    if (!any(grepl("\\bfunctions \\{", mod))) {
-      cat("functions {", mod, "}", sep = "\n", file = file_name)
+    if (!any(grepl("\\bfunctions(\\s*|)\\{", mod))) {
+      writeLines("functions {", mod, "}", sep = "\n", con = file_name)
     }
   }
   stanc_ret <- rstan::stanc(file_name, allow_undefined = TRUE,


### PR DESCRIPTION
This PR updates the handling of exporting standalone stan functions in packages for compatibility with the 2.26 versions of StanHeaders and rstan

I've added a github actions workflow which tests against a branch of the `lgpr` package which uses this feature to ensure that it works with all combinations of rstan and StanHeaders