### PR TITLE
deprecations

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rstantools
 Type: Package
 Title: Tools for Developing R Packages Interfacing with 'Stan'
-Version: 2.3.0
+Version: 2.3.0.9000
 Date: 2023-03-09
 Authors@R:
     c(person(given = "Jonah",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# rstantools 2.3.0.9000
+
+Items for next release
+
 # rstantools 2.3.0
 
 * Updated C++ standard to C++17 (#100)

--- a/R/init_cpp.R
+++ b/R/init_cpp.R
@@ -24,6 +24,7 @@
 #' `1.2.1` or later then this has already been done automatically.
 #'
 #' @export
+#' @keywords internal
 #' @param name The name of your package as a string.
 #' @param path The path to the root directory for your package as a string. If
 #'   not specified it is assumed that this is already the current working
@@ -32,6 +33,7 @@
 #'   necessary `init.cpp` file to the package's `src/` directory.
 #'
 init_cpp <- function(name, path) {
+  .Deprecated()
   file <- file.path("src", "init.cpp")
   if (!missing(path))
     file <- file.path(path, file)

--- a/R/nsamples.R
+++ b/R/nsamples.R
@@ -1,11 +1,11 @@
-#' Generic function for extracting the number of posterior samples
-#'
 #' Extract the number of posterior samples stored in a fitted Bayesian model.
 #'
 #' @export
+#' @keywords internal
 #' @template args-object
 #' @template args-dots
 #'
 nsamples <- function(object, ...) {
+  .Deprecated("ndraws from the posterior package")
   UseMethod("nsamples")
 }

--- a/R/nsamples.R
+++ b/R/nsamples.R
@@ -1,4 +1,4 @@
-#' Extract the number of posterior samples stored in a fitted Bayesian model.
+#' Generic function for extracting the number of posterior samples
 #'
 #' @export
 #' @keywords internal

--- a/man/init_cpp.Rd
+++ b/man/init_cpp.Rd
@@ -24,3 +24,4 @@ this function yourself in order to pass \verb{R CMD check} in \R
 \verb{>= 3.4}. If you used \code{rstan_package_skeleton()} in \pkg{rstantools} version
 \verb{1.2.1} or later then this has already been done automatically.
 }
+\keyword{internal}

--- a/man/nsamples.Rd
+++ b/man/nsamples.Rd
@@ -13,5 +13,6 @@ nsamples(object, ...)
 package for examples.}
 }
 \description{
-Extract the number of posterior samples stored in a fitted Bayesian model.
+Generic function for extracting the number of posterior samples
 }
+\keyword{internal}


### PR DESCRIPTION
deprecate `nsamples` (should use `ndraws` from posterior instead) and `init_cpp` (not used anymore)