### PR TITLE
Only add Makevars for current platform

### DIFF
--- a/R/rstan_config.R
+++ b/R/rstan_config.R
@@ -143,21 +143,19 @@ rstan_config <- function(pkgdir = ".") {
 # return: whether or not file(s) were successfully added/removed
 .setup_Makevars <- function(pkgdir, add = TRUE) {
   noedit_msg <- .rstantools_noedit("foo")
+  mkv_name <- ifelse(.Platform$OS.type == "windows", "Makevars.win", "Makevars")
   if (add) {
-    acc <- sapply(c("Makevars", "Makevars.win"), function(mkv_name) {
-      makevars <- readLines(.system_file(mkv_name))
-      .add_stanfile(makevars, pkgdir, "src", mkv_name,
+    makevars <- readLines(.system_file(mkv_name))
+    acc <- .add_stanfile(makevars, pkgdir, "src", mkv_name,
                     noedit = TRUE, msg = FALSE, warn = TRUE)
-    })
   } else {
-    acc <- sapply(c("Makevars", "Makevars.win"), function(mkv_name) {
-      noedit_msg <- .rstantools_noedit(mkv_name)
-      mkv_name <- file.path(pkgdir, "src", mkv_name)
-      if(file.exists(mkv_name) &&
-         (readLines(mkv_name, n = 1) == noedit_msg)) {
-        file.remove(mkv_name) # Stan file found.  remove it
-      } else FALSE # no stan file found
-    })
+    noedit_msg <- .rstantools_noedit(mkv_name)
+    mkv_name <- file.path(pkgdir, "src", mkv_name)
+    acc <- FALSE
+    if(file.exists(mkv_name) &&
+        (readLines(mkv_name, n = 1) == noedit_msg)) {
+      acc <-  file.remove(mkv_name) # Stan file found.  remove it
+    }
   }
   acc
 }


### PR DESCRIPTION
`rstan_config` currently adds both `Makevars` and `Makevars.win` on package installation, however this can cause an R CMD CHECK warning on Windows when the unix `Makevars` has CRLF line endings.

This PR updates the `.setup_makevars` function to only add the Makevars file relevant to the current platform, rather than both