### PR TITLE
Bugfix for standalone functions under 2.31

### DIFF
--- a/.github/workflows/check-standalone.yaml
+++ b/.github/workflows/check-standalone.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: local::. rcmdcheck BH RcppParallel RcppEigen Rcpp rstan StanHeaders RCurl
+          extra-packages: local::. rcmdcheck BH RcppParallel RcppEigen Rcpp rstan StanHeaders RCurl remotes
 
       - name: Checkout lgpr package
         run: |
@@ -70,6 +70,18 @@ jobs:
         shell: Rscript {0}
 
       - name: Check against Development StanHeaders and Development RStan
+        run: |
+          rcmdcheck::rcmdcheck(path = "lgpr", args = c("--no-manual", "--as-cran"), build_args = "--no-manual")
+        shell: Rscript {0}
+
+      - name: Install Experimental StanHeaders and Experimental RStan
+        run: |
+          Sys.setenv(MAKEFLAGS=paste0("-j",parallel::detectCores()))
+          remotes::install_github("stan-dev/rstan@experimental", subdir="StanHeaders")
+          remotes::install_github("stan-dev/rstan@experimental", subdir="rstan/rstan")
+        shell: Rscript {0}
+
+      - name: Check against Experimental StanHeaders and Experimental RStan
         run: |
           rcmdcheck::rcmdcheck(path = "lgpr", args = c("--no-manual", "--as-cran"), build_args = "--no-manual")
         shell: Rscript {0}

--- a/R/rstan_config.R
+++ b/R/rstan_config.R
@@ -373,7 +373,7 @@ rstan_config <- function(pkgdir = ".") {
     rm_prev <- gsub(".*\\{", "", rm_operator)
   } else {
     # Find first declaration of function (will be the forward declaration)
-    first_decl <- grep(fun_name, cpp_lines)[1]
+    first_decl <- grep(paste0(fun_name,"\\("), cpp_lines)[1]
 
     # The return type will be between the function name and the semicolon terminating
     # the previous line


### PR DESCRIPTION
There's a small bug in the exporting of standalone functions under rstan 2.31, where the extraction of plain return types was failing if two functions started with the same string (e.g., `fun1` and `fun1_2`) but had different return types.

This PR updates the regex and updates the workflow to additionally test against the `experimental` rstan branch