### PR TITLE
Suppress false-positive warning for standalone functions

### DIFF
--- a/R/rstan_config.R
+++ b/R/rstan_config.R
@@ -191,7 +191,7 @@ rstan_config <- function(pkgdir = ".") {
                     !grepl("generated[[:space:]]quantities[[:space:]]*\\{", stanc_ret$model_code)
   if (only_functions) {
     # file_name is a collection of Stan functions rather than a model
-    cppcode <- rstan::expose_stan_functions(stanc_ret, dryRun = TRUE)
+    cppcode <- suppressWarnings(suppressMessages(rstan::expose_stan_functions(stanc_ret, dryRun = TRUE)))
     cpp_lines <- scan(text = cppcode, what = character(),
                       sep = "\n", quiet = TRUE)
     cpp_lines <- cpp_lines[cpp_lines != "#include <exporter.h>"]

--- a/R/rstan_config.R
+++ b/R/rstan_config.R
@@ -211,7 +211,7 @@ rstan_config <- function(pkgdir = ".") {
     }
     # The default template parameters emitted by stanc3 can error under some clang versions
     cpp_lines <- gsub(">* = 0>", ">* = nullptr>", cpp_lines, fixed = TRUE)
-    eigen_incl <- ifelse(utils::packageVersion('rstan') >= 2.31,
+    eigen_incl <- ifelse(utils::packageVersion('StanHeaders') >= 2.31,
                          "#include <stan/math/prim/fun/Eigen.hpp>",
                          "#include <stan/math/prim/mat/fun/Eigen.hpp>")
     cat("#include <exporter.h>",


### PR DESCRIPTION
Packages exporting standalone functions via `rstantools` have been receiving the following warning during submission ([here](https://github.com/plloydsmith/rmdcev/pull/8#issuecomment-1481981897) and [here](https://github.com/jtimonen/lgpr/pull/26#issuecomment-1468784322)):
```
* checking whether package 'rmdcev' can be installed ... WARNING
Found the following significant warnings:
  WARNING: The tools required to build C++ code for R were not found
```

This warning is a false positive, as the packages compile without issue.

I've identified that this is coming from calling `rstan::expose_stan_functions()` with `rstan 2.21` when not using RStudio (it has also been seen [on the forums before](https://discourse.mc-stan.org/t/testing-user-defined-functions-with-newer-stan-functions/25040))

This PR just adds `suppressWarnings(suppressMessages())` to the `expose_functions()` call