### PR TITLE
update to match CRAN's patched version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: rstantools
 Type: Package
 Title: Tools for Developing R Packages Interfacing with 'Stan'
-Version: 2.3.1
-Date: 2023-03-29
+Version: 	2.3.1.1
+Date: 2023-07-18
 Authors@R:
     c(person(given = "Jonah",
              family = "Gabry",

--- a/R/rstan_config.R
+++ b/R/rstan_config.R
@@ -199,7 +199,7 @@ rstan_config <- function(pkgdir = ".") {
     # Stanc3 gives 'auto' return type for standalone functions, which
     #   causes errors with Rcpp::export, so need to replace the auto
     #   return with the plain type from the main definition
-    if(utils::packageVersion('rstan') >= 2.26) {
+    if(utils::packageVersion('rstan') >= "2.26") {
       # Extract line numbers of functions to be exported
       decl_lines = grep("// \\[\\[Rcpp::export]]",cpp_lines) + 1
 
@@ -211,7 +211,7 @@ rstan_config <- function(pkgdir = ".") {
     }
     # The default template parameters emitted by stanc3 can error under some clang versions
     cpp_lines <- gsub(">* = 0>", ">* = nullptr>", cpp_lines, fixed = TRUE)
-    eigen_incl <- ifelse(utils::packageVersion('StanHeaders') >= 2.31,
+    eigen_incl <- ifelse(utils::packageVersion('StanHeaders') >= "2.31",
                          "#include <stan/math/prim/fun/Eigen.hpp>",
                          "#include <stan/math/prim/mat/fun/Eigen.hpp>")
     cat("#include <exporter.h>",
@@ -229,7 +229,7 @@ rstan_config <- function(pkgdir = ".") {
                       after = class_declaration - 1L)
     # If stan model generated using stanc3, need to make sure that the rstan files are
     #   included after USE_STANC3 has been defined
-    if(utils::packageVersion('rstan') >= 2.26) {
+    if(utils::packageVersion('rstan') >= "2.26") {
       stanc3_declaration <- grep("#define USE_STANC3", cppcode)
       cppcode <- append(cppcode, values = "#include <rstan/rstaninc.hpp>",
                         after = stanc3_declaration + 1)

--- a/inst/include/sys/Makevars
+++ b/inst/include/sys/Makevars
@@ -1,6 +1,6 @@
 STANHEADERS_SRC = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "message()" -e "cat(system.file('include', 'src', package = 'StanHeaders', mustWork = TRUE))" -e "message()" | grep "StanHeaders")
 
-STANC_FLAGS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "cat(ifelse(utils::packageVersion('rstan') >= 2.26, '-DUSE_STANC3',''))")
+STANC_FLAGS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "cat(ifelse(utils::packageVersion('rstan') >= '2.26', '-DUSE_STANC3',''))")
 PKG_CPPFLAGS = -I"../inst/include" -I"$(STANHEADERS_SRC)" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DBOOST_MATH_OVERFLOW_ERROR_POLICY=errno_on_error $(STANC_FLAGS) -D_HAS_AUTO_PTR_ETC=0
 PKG_CXXFLAGS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::CxxFlags()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::CxxFlags()")
 PKG_LIBS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::RcppParallelLibs()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::LdFlags()")

--- a/inst/include/sys/Makevars.win
+++ b/inst/include/sys/Makevars.win
@@ -1,6 +1,6 @@
 STANHEADERS_SRC = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "message()" -e "cat(system.file('include', 'src', package = 'StanHeaders', mustWork = TRUE))" -e "message()" | grep "StanHeaders")
 
-STANC_FLAGS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "cat(ifelse(utils::packageVersion('rstan') >= 2.26, '-DUSE_STANC3',''))")
+STANC_FLAGS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "cat(ifelse(utils::packageVersion('rstan') >= '2.26', '-DUSE_STANC3',''))")
 PKG_CPPFLAGS = -I"../inst/include" -I"$(STANHEADERS_SRC)" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DRCPP_PARALLEL_USE_TBB=1 $(STANC_FLAGS) -D_HAS_AUTO_PTR_ETC=0
 PKG_CXXFLAGS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::CxxFlags()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::CxxFlags()")
 PKG_LIBS = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "RcppParallel::RcppParallelLibs()") $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "StanHeaders:::LdFlags()")


### PR DESCRIPTION
CRAN notified me that they uploaded a new version of rstantools with the only difference being that when checking the version numbers of rstan and StanHeaders we now use strings instead of numerics (e.g. '2.26' instead of 2.26).

This PR updates the GitHub repo to match what CRAN did. 