### PR TITLE
Fix packages with stanfunctions under rstan 2.33+

### DIFF
--- a/.github/workflows/check-standalone.yaml
+++ b/.github/workflows/check-standalone.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Checkout lgpr package
         run: |
           git clone https://github.com/andrjohns/lgpr
-          git checkout array-syntax
+          cd lgpr && git checkout array-syntax
 
       - name: Check against CRAN StanHeaders and CRAN RStan
         run: |

--- a/.github/workflows/check-standalone.yaml
+++ b/.github/workflows/check-standalone.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: local::. rcmdcheck BH RcppParallel RcppEigen Rcpp rstan StanHeaders RCurl remotes
+          extra-packages: local::. rcmdcheck BH RcppParallel RcppEigen Rcpp rstan StanHeaders RCurl remotes V8
 
       - name: Checkout lgpr package
         run: |

--- a/.github/workflows/check-standalone.yaml
+++ b/.github/workflows/check-standalone.yaml
@@ -42,7 +42,8 @@ jobs:
 
       - name: Checkout lgpr package
         run: |
-          git clone https://github.com/jtimonen/lgpr
+          git clone https://github.com/andrjohns/lgpr
+          git checkout array-syntax
 
       - name: Check against CRAN StanHeaders and CRAN RStan
         run: |

--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -42,7 +42,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: rcmdcheck BH RcppParallel RcppEigen Rcpp rstan StanHeaders
+          extra-packages: rcmdcheck BH RcppParallel RcppEigen Rcpp rstan StanHeaders V8
 
       - name: Check against CRAN StanHeaders and CRAN RStan
         uses: r-lib/actions/check-r-package@v2

--- a/R/rstan_config.R
+++ b/R/rstan_config.R
@@ -199,7 +199,7 @@ rstan_config <- function(pkgdir = ".") {
     # Stanc3 gives 'auto' return type for standalone functions, which
     #   causes errors with Rcpp::export, so need to replace the auto
     #   return with the plain type from the main definition
-    if(utils::packageVersion('rstan') >= "2.26") {
+    if(utils::packageVersion('rstan') >= "2.26" && utils::packageVersion('StanHeaders') < "2.33") {
       # Extract line numbers of functions to be exported
       decl_lines = grep("// \\[\\[Rcpp::export]]",cpp_lines) + 1
 


### PR DESCRIPTION
This PR resolves a similar issue as this `cmdstanr` PR: https://github.com/stan-dev/cmdstanr/pull/847

After 2.33 `stanc3` will emit plain types for standalone functions instead of `auto`, so we no longer need to pre-process the `hpp` to do this ourselves.

This PR is needed for rstan 2.33 compatibility with packages like `lgpr` and `rmdcev` which export standalone functions during installation