### PR TITLE
Update CI to use r-universe rstan

### DIFF
--- a/.github/workflows/check-standalone.yaml
+++ b/.github/workflows/check-standalone.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: Install Development StanHeaders and CRAN RStan
         run: |
           Sys.setenv(MAKEFLAGS=paste0("-j",parallel::detectCores()))
-          install.packages("StanHeaders", repos = c("https://mc-stan.org/r-packages/", getOption("repos")))
+          install.packages("StanHeaders", repos = c("https://stan-dev.r-universe.dev", getOption("repos")))
           install.packages('rstan', type='source')
         shell: Rscript {0}
 
@@ -64,32 +64,11 @@ jobs:
       - name: Install Development StanHeaders and Development RStan
         run: |
           Sys.setenv(MAKEFLAGS=paste0("-j",parallel::detectCores()))
-          install.packages("StanHeaders", repos = c("https://mc-stan.org/r-packages/", getOption("repos")))
-          install.packages("rstan", repos = c("https://mc-stan.org/r-packages/", getOption("repos")))
+          install.packages("StanHeaders", repos = c("https://stan-dev.r-universe.dev", getOption("repos")))
+          install.packages("rstan", repos = c("https://stan-dev.r-universe.dev", getOption("repos")))
         shell: Rscript {0}
 
       - name: Check against Development StanHeaders and Development RStan
         run: |
           rcmdcheck::rcmdcheck(path = "lgpr", args = c("--no-manual", "--as-cran"), build_args = "--no-manual")
         shell: Rscript {0}
-
-      - name: Checkout RStan Experimental branch
-        uses: actions/checkout@v3
-        with:
-          repository: stan-dev/rstan
-          ref: experimental
-          path: rstan
-          submodules: 'recursive'
-
-      - name: Install Experimental StanHeaders and Experimental RStan
-        run: |
-          Sys.setenv(MAKEFLAGS=paste0("-j",parallel::detectCores()))
-          install.packages("rstan/StanHeaders", type = "source", repos = NULL)
-          install.packages("rstan/rstan/rstan", type = "source", repos = NULL)
-        shell: Rscript {0}
-
-      - name: Check against Experimental StanHeaders and Experimental RStan
-        run: |
-          rcmdcheck::rcmdcheck(path = "lgpr", args = c("--no-manual", "--as-cran"), build_args = "--no-manual")
-        shell: Rscript {0}
-

--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Install Development StanHeaders and CRAN RStan
         run: |
           Sys.setenv(MAKEFLAGS=paste0("-j",parallel::detectCores()))
-          install.packages("StanHeaders", repos = c("https://mc-stan.org/r-packages/", getOption("repos")))
+          install.packages("StanHeaders", repos = c("https://stan-dev.r-universe.dev", getOption("repos")))
           install.packages('rstan', type='source')
         shell: Rscript {0}
 
@@ -60,8 +60,8 @@ jobs:
       - name: Install Development StanHeaders and Development RStan
         run: |
           Sys.setenv(MAKEFLAGS=paste0("-j",parallel::detectCores()))
-          install.packages("StanHeaders", repos = c("https://mc-stan.org/r-packages/", getOption("repos")))
-          install.packages("rstan", repos = c("https://mc-stan.org/r-packages/", getOption("repos")))
+          install.packages("StanHeaders", repos = c("https://stan-dev.r-universe.dev", getOption("repos")))
+          install.packages("rstan", repos = c("https://stan-dev.r-universe.dev", getOption("repos")))
         shell: Rscript {0}
 
       - name: Check against Development StanHeaders and Development RStan


### PR DESCRIPTION
Also removes checking against rstan `experimental`, now that `develop` is the main source