### PR TITLE
Fix roxygen2 warning

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,6 +53,6 @@ Suggests:
     roxygen2 (>= 6.0.1),
     rmarkdown,
     rstudioapi
-RoxygenNote: 7.3.0
+RoxygenNote: 7.3.2
 VignetteBuilder: knitr
 Roxygen: list(markdown = TRUE)

--- a/R/rstantools-package.R
+++ b/R/rstantools-package.R
@@ -2,7 +2,6 @@
 #'
 #' @name rstantools-package
 #' @aliases rstantools
-#' @docType package
 #'
 #' @description
 #' \if{html}{
@@ -21,7 +20,7 @@
 #'
 #' @importFrom RcppParallel RcppParallelLibs
 #'
-NULL
+"_PACKAGE"
 
 
 # internal ----------------------------------------------------------------


### PR DESCRIPTION
This fixes the following warning when compiling the documentation:

> rstantools-package.R:24: `@docType "package"` is deprecated.