### PR TITLE
Add fallback package name in case the DESCRIPTION file cannot be read

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,9 @@
 
 Items for next release go here
 
-Extended `loo_pit()` for discrete data.
+* Extended `loo_pit()` for discrete data.
+* Fix regression (introduced in 2.4.0) in the compilation of packages with
+custom Stan functions by @mcol in #137
 
 # rstantools 2.4.0
 

--- a/R/rstan_config.R
+++ b/R/rstan_config.R
@@ -214,7 +214,10 @@ rstan_config <- function(pkgdir = ".") {
     eigen_incl <- ifelse(utils::packageVersion('StanHeaders') >= "2.31",
                          "#include <stan/math/prim/fun/Eigen.hpp>",
                          "#include <stan/math/prim/mat/fun/Eigen.hpp>")
-    pkgname <- unname(read.dcf("DESCRIPTION", "Package")[1, 1])
+    pkgname <- tryCatch(unname(read.dcf("DESCRIPTION", "Package")[1, 1]),
+                        warning = function(w) {
+                          basename(pkgdir)
+                        })
     cat("#include <exporter.h>",
         eigen_incl,
         "#include <stan/math/prim/meta.hpp>",


### PR DESCRIPTION
When the DESCRIPTION file is not present, the package name is inferred to be `basename(pkgdir)`, which is what it used to be before #130.

Fixes #135.