### PR TITLE
Remove C++14 from SystemRequirements

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,7 +41,7 @@ URL: https://mc-stan.org/rstantools/, https://discourse.mc-stan.org/
 BugReports: https://github.com/stan-dev/rstantools/issues
 Encoding: UTF-8
 LazyData: true
-SystemRequirements: pandoc, C++14
+SystemRequirements: pandoc
 Imports: desc, stats, utils, Rcpp (>= 0.12.16), RcppParallel (>= 5.0.1)
 Suggests:
     rstan (>= 2.17.2),


### PR DESCRIPTION
CRAN requested this and we don't need it anymore. 