### PR TITLE
add BH, RcppEigen to pkgdown workflow file instead of Suggests

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::pkgdown, local::., any::withr, stan-dev/pkgdown-config
+          extra-packages: any::pkgdown, local::., any::withr, stan-dev/pkgdown-config, any::BH, any::RcppEigen
 
       - name: Build site
         run: |

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,8 +48,6 @@ SystemRequirements: pandoc
 Imports: desc, stats, utils, Rcpp (>= 0.12.16), RcppParallel (>= 5.0.1)
 Suggests:
     rstan (>= 2.17.2),
-    BH (>= 1.66.0),
-    RcppEigen (>= 0.3.3.3.0),
     usethis (>= 1.5.1),
     testthat (>= 2.0.0),
     knitr,


### PR DESCRIPTION
@andrjohns let's merge this before the CRAN release. I had put these packages in Suggests to get the vignette to build but they should just go in the workflow file since rstantools doesn't directly call them 

Also thanks to work from @VisruthSK the website shouldn't need to be manually updated, it should update automatically when you tag the GitHub release (or maybe even just when changing the version number on the master branch)